### PR TITLE
Fixing 404 links to validatedpatterns.io

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -580,6 +580,7 @@ userid
 useroperator
 usr
 util
+validatedpatterns
 vcpu
 vcpus
 vdvkgdtuxkeqf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hybrid Cloud Patterns documentation site
 
-This project contains the new proof-of-concept documentation site for hybrid-cloud-patterns.io
+This project contains the new proof-of-concept documentation site for validatedpatterns.io
 
 You can build this site using [Hugo](https://gohugo.io/).
 

--- a/content/blog/2021-12-31-medical-diagnosis.md
+++ b/content/blog/2021-12-31-medical-diagnosis.md
@@ -22,15 +22,15 @@ The purpose of this pattern is to show how medical facilities can take full adva
 
 The image is uploaded to an S3-compatible object storage. This upload triggers an event from the storage, “a new image has been uploaded”,  that is sent into a Kafka topic. This topic is consumed by a KNative Eventing listener that triggers the launch of a KNative Serving instance. This instance is a containerimage  with the AI/ML model and the needed processing functions. Based on the information from the event it received, the container retrieves the image from the object store, pre-processes it, makes a prediction on the risk of pneumonia using the AI/ML model, and saves the result. A notification of those results is sent to the medical staff as well.
 
-[![physical-dataflow](https://hybrid-cloud-patterns.io/images/medical-edge/physical-dataflow.png)](https://hybrid-cloud-patterns.io/images/medical-edge/physical-dataflow.png)
+[![physical-dataflow](https://validatedpatterns.io/images/medical-edge/physical-dataflow.png)](https://validatedpatterns.io/images/medical-edge/physical-dataflow.png)
 
-For a recorded demo deploying the pattern and seeing the dashboards available to the user, check out our [docs page](https://hybrid-cloud-patterns.io/medical-diagnosis/)!
+For a recorded demo deploying the pattern and seeing the dashboards available to the user, check out our [docs page](https://validatedpatterns.io/medical-diagnosis/)!
 
 ## Pattern Deployment
 
 ---
 
-To deploy this pattern, follow the instructions outlined on the [getting-started](https://hybrid-cloud-patterns.io/medical-diagnosis/getting-started/) page.
+To deploy this pattern, follow the instructions outlined on the [getting-started](https://validatedpatterns.io/medical-diagnosis/getting-started/) page.
 
 ### What's happening?
 

--- a/content/blog/2022-03-30-multicloud-gitops.md
+++ b/content/blog/2022-03-30-multicloud-gitops.md
@@ -80,4 +80,4 @@ The config-demo namespace uses a deployment of the Red Hat Universal Base Image 
 
 One of the next things we are committed to delivering in the new year is a pattern to extend the concept of GitOps to include elements that are outside of OpenShift and Kubernetes - specifically Red Hat Enterprise Linux nodes, including Red Hat Enterprise Linux For Edge nodes, as well as Red Hat Ansible Automation Platform.
 
-We plan on developing a number of new patterns throughout the new year, which will showcase various technologies.  Keep watching this space for updates, and if you would like to get involved, visit our site at [https://hybrid-cloud-patterns.io](https://hybrid-cloud-patterns.io)!
+We plan on developing a number of new patterns throughout the new year, which will showcase various technologies.  Keep watching this space for updates, and if you would like to get involved, visit our site at [https://validatedpatterns.io](https://validatedpatterns.io)!

--- a/content/blog/2022-09-02-route.md
+++ b/content/blog/2022-09-02-route.md
@@ -148,4 +148,4 @@ As you can see the *subdomain* property was replaced with the *host* property bu
 
 Using the *subdomain* property when defining route is super useful if you are deploying your application to different clusters and it will allow you to not have to hard code the ingress domain for every cluster.
 
-If you have any questions or want to see what we are working on please feel free to visit our [Hybrid Cloud Patterns](https://hybrid-cloud-patterns.io/) site. If you are excited or intrigued by what you see here we’d love to hear your thoughts and ideas! Try the patterns contained in our [Hybrid Cloud Patterns Repo](https://github.com/hybrid-cloud-patterns). We will review your pull requests to our pattern repositories.
+If you have any questions or want to see what we are working on please feel free to visit our [Hybrid Cloud Patterns](https://validatedpatterns.io/) site. If you are excited or intrigued by what you see here we’d love to hear your thoughts and ideas! Try the patterns contained in our [Hybrid Cloud Patterns Repo](https://github.com/hybrid-cloud-patterns). We will review your pull requests to our pattern repositories.

--- a/content/blog/2022-10-12-acm-provisioning.md
+++ b/content/blog/2022-10-12-acm-provisioning.md
@@ -39,7 +39,7 @@ the pay-as-you-go OpenShift managed service.
 | ------------------------------ |
 | [![Installing a validated pattern](https://img.youtube.com/vi/N6XPh-9XZAM/mqdefault.jpg "Installing a validated pattern")](https://youtu.be/N6XPh-9XZAM) |
 
-Start by [deploying](https://hybrid-cloud-patterns.io/multicloud-gitops/getting-started/) the Multi-cloud GitOps pattern on AWS.
+Start by [deploying](https://validatedpatterns.io/multicloud-gitops/getting-started/) the Multi-cloud GitOps pattern on AWS.
 
 Next, you'll need to create a fork of the [multicloud-gitops](https://github.com/hybrid-cloud-patterns/multicloud-gitops/)
 repo.  Go there in a browser, make sure you’re logged in to GitHub, click the
@@ -48,9 +48,9 @@ fork" button.
 
 Now you have a copy of the pattern that you can make changes to.  You can read
 more about the Multi-cloud GitOps pattern on our [community
-site](https://hybrid-cloud-patterns.io/multicloud-gitops/)
+site](https://validatedpatterns.io/multicloud-gitops/)
 
-Next, [install the Validated Patterns operator](https://hybrid-cloud-patterns.io/infrastructure/using-validated-pattern-operator/) from Operator Hub.
+Next, [install the Validated Patterns operator](https://validatedpatterns.io/infrastructure/using-validated-pattern-operator/) from Operator Hub.
 
 And finally, click through to the installed operator, and select the `Create
 instance` button and fill out the Create a Pattern form.  Most of the defaults
@@ -150,7 +150,7 @@ should be delivered to the cluster.
 
 `.labels` tells ACM how to decide which clusters get this site configuration.  If
 you were building and [importing
-clusters](https://hybrid-cloud-patterns.io/industrial-edge/factory/) yourself,
+clusters](https://validatedpatterns.io/industrial-edge/factory/) yourself,
 these are the labels you would need to specify during the import process.  You
 can specify different and/or additional labels, but the default is to use
 `clusterGroup={name of the group}`

--- a/content/blog/2022-11-20-argo-rollouts.md
+++ b/content/blog/2022-11-20-argo-rollouts.md
@@ -60,7 +60,7 @@ If you've never deployed OpenShift before, you could try [ROSA](https://cloud.re
 Next, you'll need to create a fork of the [argo-rollouts](https://github.com/hybrid-cloud-patterns/argo-rollouts/) repo.
 Go there in a browser, make sure you’re logged in to GitHub, click the “Fork” button, and confirm the destination by clicking the big green "Create fork" button.
 
-Next, [install the Validated Patterns operator](https://hybrid-cloud-patterns.io/infrastructure/using-validated-pattern-operator/) from Operator Hub.
+Next, [install the Validated Patterns operator](https://validatedpatterns.io/infrastructure/using-validated-pattern-operator/) from Operator Hub.
 
 And finally, click through to the installed operator, and select the `Create
 instance` button and fill out the Create a Pattern form.  Most of the defaults

--- a/content/contribute/background-on-pattern-development.md
+++ b/content/contribute/background-on-pattern-development.md
@@ -91,12 +91,12 @@ There are two approaches to secret handling with validated patterns:
 - Using special configuration files. This is fine for initial development but not for production.
 - Using a Cloud Native secrets handling tool e.g. [Vault](https://www.vaultproject.io/docs/platform/k8s) or [Conjur](https://www.conjur.org/solutions/secrets-management/)
 
-Some of the validated patterns use configuration files (for now), while others, like the [Multicloud GitOps](https://hybrid-cloud-patterns.io/multicloud-gitops/), use Vault. See [Vault Setup](https://hybrid-cloud-patterns.io/secrets/vault/) for more info.
+Some of the validated patterns use configuration files (for now), while others, like the [Multicloud GitOps](https://validatedpatterns.io/multicloud-gitops/), use Vault. See [Vault Setup](https://validatedpatterns.io/secrets/vault/) for more info.
 
 ## Policy
 
 While many enterprise Cloud Native applications are open source, many of the products used require licenses or subscriptions. Policies help enforce license and subscription management and the channels needed to get access to those licenses or subscriptions.
 
-Similarly, in multicloud deployments and complex edge deployments, policies can help define and select the correct GitOps workflows that need to be managed for various sites or clusters. E.g. defining an OpenShift Cluster as a "Factory" in the [Industrial Edge](https://hybrid-cloud-patterns.io/industrial-edge/factory/) validated pattern provides a simple trigger to roll-out the entire Factory deployment. Policy is a powerful tool in automation.
+Similarly, in multicloud deployments and complex edge deployments, policies can help define and select the correct GitOps workflows that need to be managed for various sites or clusters. E.g. defining an OpenShift Cluster as a "Factory" in the [Industrial Edge](https://validatedpatterns.io/industrial-edge/factory/) validated pattern provides a simple trigger to roll-out the entire Factory deployment. Policy is a powerful tool in automation.
 
 Validated patterns use [Red Hat Advanced Cluster Management for Kubernetes](https://www.redhat.com/en/technologies/management/advanced-cluster-management) to control clusters and applications from a single console, with built-in security policies.

--- a/content/contribute/creating-a-pattern.md
+++ b/content/contribute/creating-a-pattern.md
@@ -130,7 +130,7 @@ applications:
 
 In the above example `acm` (ACM) is part of the main `datacenter` deployment, as is `cool-app`. However, `central-kafka` is part of `backend-storage`.
 
-The `path:` tag tells OpenShift GitOps where to find the Helm charts needed to deploy this application (refer back to the [charts directory description](https://hybrid-cloud-patterns.io/building-vps/structure/#the-charts-directory) for more details). OpenShift GitOps will continuously monitor for changes to artifacts in that location for updates to apply.
+The `path:` tag tells OpenShift GitOps where to find the Helm charts needed to deploy this application (refer back to the [charts directory description](https://validatedpatterns.io/building-vps/structure/#the-charts-directory) for more details). OpenShift GitOps will continuously monitor for changes to artifacts in that location for updates to apply.
 
 Each different site type would have its own values- file listing subscriptions and applications.
 
@@ -178,4 +178,4 @@ spec:
 
 ## Size matters
 
-If things are taking a long time to deploy, use the OpenShift console to check on memory and other potential capacity issues with the cluster. If running in a cloud you may wish to up the machine size. Check the [sizing charts](https://hybrid-cloud-patterns.io/infrastructure/).
+If things are taking a long time to deploy, use the OpenShift console to check on memory and other potential capacity issues with the cluster. If running in a cloud you may wish to up the machine size. Check the [sizing charts](https://validatedpatterns.io/infrastructure/).

--- a/content/learn/faq.md
+++ b/content/learn/faq.md
@@ -56,4 +56,4 @@ Excited or intrigued by what you see here?  We'd love to hear your thoughts and 
 
 Try out what we've done and submit issues to our [issue trackers](https://github.com/hybrid-cloud-patterns/industrial-edge/issues).
 
-We will review pull requests to our [pattern](https://github.com/hybrid-cloud-patterns/common) [repositories](https://hybrid-cloud-patterns.io/industrial-edge).
+We will review pull requests to our [pattern](https://github.com/hybrid-cloud-patterns/common) [repositories](https://validatedpatterns.io/industrial-edge).

--- a/content/patterns/ansible-edge-gitops/getting-started.md
+++ b/content/patterns/ansible-edge-gitops/getting-started.md
@@ -228,7 +228,7 @@ The container used for this pattern is the container [image](https://hub.docker.
 ## HashiCorp [Vault](https://www.vaultproject.io/)
 
 Vault is used as the authoritative source for the Kiosk ssh pubkey via the External Secrets Operator.
-As part of this pattern HashiCorp Vault has been installed. Refer to the section on [Vault](https://hybrid-cloud-patterns.io/secrets/vault/).
+As part of this pattern HashiCorp Vault has been installed. Refer to the section on [Vault](https://validatedpatterns.io/secrets/vault/).
 
 # Next Steps
 

--- a/content/patterns/devsecops/getting-started.md
+++ b/content/patterns/devsecops/getting-started.md
@@ -272,8 +272,8 @@ Once the hub has been setup correctly and confirmed to be working, you can:
 1. Add a dedicated production cluster to [deploy production using ACM](/devsecops/production-cluster)
 1. Once the hub, production and devel clusters have been deployed you will want to check out and test the Multi-Cluster DevSecOps demo code. You can find that here TBD
 
-   a. Making [configuration changes](https://hybrid-cloud-patterns.io/devsecops/) with GitOps TBD
-   a. Making [application changes](https://hybrid-cloud-patterns.io/devsecops/) using DevOps TBD
+   a. Making [configuration changes](https://validatedpatterns.io/devsecops/) with GitOps TBD
+   a. Making [application changes](https://validatedpatterns.io/devsecops/) using DevOps TBD
 
 # Uninstalling
 

--- a/content/patterns/industrial-edge/getting-started.md
+++ b/content/patterns/industrial-edge/getting-started.md
@@ -235,9 +235,9 @@ Once the data center has been setup correctly and confirmed to be working, you c
 1. Add a dedicated cluster to [deploy the factory pieces using ACM](/industrial-edge/factory)
 2. Once the data center and the factory have been deployed you will want to check out and test the Industrial Edge 2.0 demo code. You can find that [here](../application/)
 
-   a. Making [configuration changes](https://hybrid-cloud-patterns.io/industrial-edge/application/#configuration-changes-with-gitops) with GitOps
-   a. Making [application changes](https://hybrid-cloud-patterns.io/industrial-edge/application/#application-changes-using-devops) using DevOps
-   a. Making [AI/ML model changes](https://hybrid-cloud-patterns.io/industrial-edge/application/#application-ai-model-changes-with-devops) with DevOps
+   a. Making [configuration changes](https://validatedpatterns.io/industrial-edge/application/#configuration-changes-with-gitops) with GitOps
+   a. Making [application changes](https://validatedpatterns.io/industrial-edge/application/#application-changes-using-devops) using DevOps
+   a. Making [AI/ML model changes](https://validatedpatterns.io/industrial-edge/application/#application-ai-model-changes-with-devops) with DevOps
 
 # Uninstalling
 

--- a/content/patterns/industrial-edge/ideas-for-customization.md
+++ b/content/patterns/industrial-edge/ideas-for-customization.md
@@ -16,7 +16,7 @@ This demo in particular can be customized in a number of ways that might be very
 
 Hopefully we are all familiar with GitHub.  If you are not GitHub is a code hosting platform for version control and collaboration. It lets you and others work together on projects from anywhere.  Our Industrial Edge GitOps repository is available in our [Hybrid Cloud Patterns GitHub](https://github.com/hybrid-cloud-patterns "Hybrid Cloud Patterns Homepage") organization.
 
-To fork this repository, and deploy the Industrial Edge pattern, follow the steps found in our [Getting Started](https://hybrid-cloud-patterns.io/industrial-edge/getting-started "Industrial Edge Getting Started Guide") section.  This will allow you to follow the next few HOWTO guides in this section.
+To fork this repository, and deploy the Industrial Edge pattern, follow the steps found in our [Getting Started](https://validatedpatterns.io/industrial-edge/getting-started "Industrial Edge Getting Started Guide") section.  This will allow you to follow the next few HOWTO guides in this section.
 
 Our sensors have been configured to send data relating to the vibration of the devices.  To show the power of GitOps, and keeping state in a git repository, we can make a change to the config map of one of the sensors to detect and report data on temperature. This is done via a variable called *SENSOR_TEMPERATURE_ENABLED* that is initially set to false.  Setting this variable to true will trigger the GitOps engine to synchronize the application, restart the machine sensor and apply the change.
 

--- a/content/patterns/medical-diagnosis/getting-started.adoc
+++ b/content/patterns/medical-diagnosis/getting-started.adoc
@@ -15,7 +15,7 @@ aliases: /medical-diagnosis/getting-started/
 . S3-capable Storage set up in your public/private cloud for the x-ray images
 . The helm binary, see link:https://helm.sh/docs/intro/install/[here]
 
-For installation tooling dependencies, see link:https://hybrid-cloud-patterns.io/learn/quickstart/[Patterns quick start].
+For installation tooling dependencies, see link:https://validatedpatterns.io/learn/quickstart/[Patterns quick start].
 
 The use of this pattern depends on having a Red Hat OpenShift cluster. In this version of the validated pattern
 there is no dedicated Hub / Edge cluster for the *Medical Diagnosis* pattern.

--- a/content/patterns/multicloud-gitops-Portworx/getting-started.md
+++ b/content/patterns/multicloud-gitops-Portworx/getting-started.md
@@ -25,7 +25,7 @@ service](https://console.redhat.com/openshift/create).
 
 ## Procedure
 
-1. For installation tooling dependencies, see link:https://hybrid-cloud-patterns.io/learn/quickstart/[Patterns quick start].
+1. For installation tooling dependencies, see link:https://validatedpatterns.io/learn/quickstart/[Patterns quick start].
 
    {% include prerequisite-tools.md %}
 
@@ -94,7 +94,7 @@ To deploy the cluster by using the `pattern.sh` file, complete the following ste
 
 ## Multicloud GitOps application demos
 
-As part of this pattern, HashiCorp Vault has been installed. Refer to the section on [Vault](https://hybrid-cloud-patterns.io/secrets/vault/).
+As part of this pattern, HashiCorp Vault has been installed. Refer to the section on [Vault](https://validatedpatterns.io/secrets/vault/).
 
 <!--The Next steps heading is not inline with the chapter and only points to contibution links for help and feedback or bugs -->
 # Next steps
@@ -103,7 +103,7 @@ As part of this pattern, HashiCorp Vault has been installed. Refer to the sectio
 
 After the management hub is set up and works correctly, attach one or more managed clusters to the architecture (see diagrams below).
 
-For instructions on deploying the edge, refer to [Managed Cluster Sites](https://hybrid-cloud-patterns.io/patterns/multicloud-gitops-portworx/managed-cluster/).
+For instructions on deploying the edge, refer to [Managed Cluster Sites](https://validatedpatterns.io/patterns/multicloud-gitops-portworx/managed-cluster/).
 
 >Contribute to this pattern:
 {{% button text="Help & Feedback" url="https://groups.google.com/g/hybrid-cloud-patterns" %}}

--- a/modules/contributing.adoc
+++ b/modules/contributing.adoc
@@ -51,5 +51,5 @@ When you submit a PR, the https://github.com/orgs/hybrid-cloud-patterns/teams/do
 
 //to-do: commenting out this section since presently this is rendered as one single page and the topics under the link immediately follow the "Next steps" section. Originally, the links under the "Next steps" section were meant to open as new pages, which they currently don't.
 //== Next steps
-//* link:https://hybrid-cloud-patterns.io/contribute/contribute-to-docs/#contributing-to-docs-tools-and-setup[Install and set up the tools and software] on your workstation so that you can contribute.
-//* link:https://hybrid-cloud-patterns.io/contribute/contribute-to-docs/#contributing-to-docs-doc-guidelines[Review the documentation guidelines] to understand some basic guidelines to keep documentation consistent across our content.
+//* link:https://validatedpatterns.io/contribute/contribute-to-docs/#contributing-to-docs-tools-and-setup[Install and set up the tools and software] on your workstation so that you can contribute.
+//* link:https://validatedpatterns.io/contribute/contribute-to-docs/#contributing-to-docs-doc-guidelines[Review the documentation guidelines] to understand some basic guidelines to keep documentation consistent across our content.

--- a/modules/mcg-deploying-mcg-pattern.adoc
+++ b/modules/mcg-deploying-mcg-pattern.adoc
@@ -22,7 +22,7 @@ public or private cloud by using https://console.redhat.com/openshift/create[Red
 
 .Procedure
 
-. https://hybrid-cloud-patterns.io/learn/quickstart/[Install the tooling dependencies].
+. https://validatedpatterns.io/learn/quickstart/[Install the tooling dependencies].
 +
 . Fork the https://github.com/hybrid-cloud-patterns/multicloud-gitops[multicloud-gitops] repository on GitHub.
 . Clone the forked copy of this repository.
@@ -112,4 +112,4 @@ Optional: Set the `KUBECONFIG` variable for the `kubeconfig` file path:
 image::multicloud-gitops/multicloud-gitops-argocd.png[Multicloud GitOps Hub]
 
 
-As part of this pattern, HashiCorp Vault has been installed. Refer to the section on https://hybrid-cloud-patterns.io/secrets/vault/[Vault].
+As part of this pattern, HashiCorp Vault has been installed. Refer to the section on https://validatedpatterns.io/secrets/vault/[Vault].

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -95,7 +95,7 @@ function get_shield_url(badge, label, links) {
 }
 
 function get_key_url(color, label, links) {
-    uri = 'https://hybrid-cloud-patterns.io/'+color+'.json';
+    uri = 'https://validatedpatterns.io/'+color+'.json';
     base = 'https://img.shields.io/endpoint?style=flat&logo=git&logoColor=white';
 
     base = base +'&link='+ encodeURI("/") + '&link=' + encodeURI(uri);
@@ -150,7 +150,7 @@ function jenkins_base_url(key) {
 }
 
 function pattern_url(key) {
-    const prefix = 'https://hybrid-cloud-patterns.io/patterns/'
+    const prefix = 'https://validatedpatterns.io/patterns/'
     const dictionary = {
 	aegitops: "ansible-edge-gitops",
 	devsecops: "devsecops",

--- a/static/js/dashboard.v2.js
+++ b/static/js/dashboard.v2.js
@@ -85,7 +85,7 @@ function get_shield_url (badge, label) {
 }
 
 function get_key_url (color, label) {
-  uri = 'https://hybrid-cloud-patterns.io/' + color + '.json'
+  uri = 'https://validatedpatterns.io/' + color + '.json'
   base = 'https://img.shields.io/endpoint?style=flat&logo=git&logoColor=white'
 
   base = base + '&link=' + encodeURI('/') + '&link=' + encodeURI(uri)


### PR DESCRIPTION
These are links that point to the old hybrid-cloud-patterns.io. Now they point to the new site. This should also fix our failing htmltest jobs.