### PR TITLE
The original link points to a We Have Moved organization

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
                         <ul class="pf-c-list pf-m-plain">
                             <li>
                                 <i class="prefooter-icon fa-brands fa-github"></i>
-                                <a class="footer-link" aria-label="GitHub repository" href="https://github.com/hybrid-cloud-patterns">GitHub repository</a>
+                                <a class="footer-link" aria-label="GitHub repository" href="https://github.com/validatedpatterns/docs">GitHub repository</a>
                             </li>
                             <li>
                                 <i class="prefooter-icon fas fa-check-circle"></i>


### PR DESCRIPTION
The original link points to a We Have Moved organization; also, link directly to the repository.