### PR TITLE
The console.redhat.com site currently has no top-level OpenShift link or menu.

### DIFF
--- a/content/patterns/medical-diagnosis/getting-started.adoc
+++ b/content/patterns/medical-diagnosis/getting-started.adoc
@@ -19,7 +19,7 @@ include::modules/comm-attributes.adoc[]
 
 * An OpenShift cluster
  ** To create an OpenShift cluster, go to the https://console.redhat.com/[Red Hat Hybrid Cloud console].
- ** Select *OpenShift* -> *Clusters* -> *Create cluster*.
+ ** Select *Services* -> *Containers* -> *Create cluster*.
  ** The cluster must have a dynamic `StorageClass` to provision `PersistentVolumes`. See link:../../medical-diagnosis/cluster-sizing[sizing your cluster].
 * A GitHub account and a token for it with repositories permissions, to read from and write to your forks.
 * An S3-capable Storage set up in your public or private cloud for the x-ray images

--- a/content/patterns/multicloud-gitops-Portworx/getting-started.md
+++ b/content/patterns/multicloud-gitops-Portworx/getting-started.md
@@ -10,7 +10,7 @@ aliases: /multicloud-gitops/getting-started/
 
 * An OpenShift cluster
   * To create an OpenShift cluster, go to the [Red Hat Hybrid Cloud console](https://console.redhat.com/).
-  * Select **OpenShift -> Clusters -> Create cluster**.
+  * Select **Services -> Containers -> Create cluster**.
   * The cluster must have a dynamic `StorageClass` to provision `PersistentVolumes`. See [sizing your cluster](../../multicloud-gitops/mcg-cluster-sizing).
 * Optional: A second OpenShift cluster for multicloud demonstration.
 * The git binary and podman. For details see [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Installing Podman](https://podman.io/getting-started/installation)

--- a/content/patterns/multicloud-gitops-Portworx/managed-cluster.md
+++ b/content/patterns/multicloud-gitops-Portworx/managed-cluster.md
@@ -61,7 +61,7 @@ Ensure that you commit the changes and push them to GitHub so that GitOps can fe
 
 * An OpenShift cluster
   * To create an OpenShift cluster, go to the [Red Hat Hybrid Cloud console](https://console.redhat.com/).
-  * Select **OpenShift -> Clusters -> Create cluster**.
+  * Select **Services -> Containers -> Create cluster**.
 
 To join the managed cluster to the management hub, you can:
 

--- a/modules/comm-deploying-managed-cluster-using-clusteradm-tool.adoc
+++ b/modules/comm-deploying-managed-cluster-using-clusteradm-tool.adoc
@@ -8,7 +8,7 @@
 
 * An OpenShift cluster
  ** To create an OpenShift cluster, go to the https://console.redhat.com/[Red Hat Hybrid Cloud console].
- ** Select *OpenShift* -> *Clusters* -> *Create cluster*.
+ ** Select *Services* -> *Containers* -> *Create cluster*.
 
 * https://github.com/open-cluster-management-io/clusteradm#install-the-clusteradm-command-line[The `clusteradm` tool]
 

--- a/modules/comm-deploying-managed-cluster-using-cm-cli-tool.adoc
+++ b/modules/comm-deploying-managed-cluster-using-cm-cli-tool.adoc
@@ -8,7 +8,7 @@
 
 * An OpenShift cluster
  ** To create an OpenShift cluster, go to the https://console.redhat.com/[Red Hat Hybrid Cloud console].
- ** Select *OpenShift \-> Clusters \-> Create cluster*.
+ ** Select *Services \-> Containers \-> Create cluster*.
 
 * https://github.com/open-cluster-management/cm-cli/#installation[The `cm-cli` tool]
 

--- a/modules/mcg-deploying-managed-cluster-using-rhacm.adoc
+++ b/modules/mcg-deploying-managed-cluster-using-rhacm.adoc
@@ -8,7 +8,7 @@
 
 * An OpenShift cluster
  ** To create an OpenShift cluster, go to the https://console.redhat.com/[Red Hat Hybrid Cloud console].
- ** Select *OpenShift* -> *Clusters* -> *Create cluster*.
+ ** Select *Services* -> *Containers* -> *Create cluster*.
 
 * Red Hat Advanced Cluster Management (RHACM) web console to join the managed cluster to the management hub
 +

--- a/modules/mcg-deploying-mcg-pattern.adoc
+++ b/modules/mcg-deploying-mcg-pattern.adoc
@@ -8,7 +8,7 @@
 
 * An OpenShift cluster
  ** To create an OpenShift cluster, go to the https://console.redhat.com/[Red Hat Hybrid Cloud console].
- ** Select *OpenShift \-> Clusters \-> Create cluster*.
+ ** Select *Services \-> Containers \-> Create cluster*.
  ** The cluster must have a dynamic `StorageClass` to provision `PersistentVolumes`. See link:../../multicloud-gitops/mcg-cluster-sizing[sizing your cluster].
 * Optional: A second OpenShift cluster for multicloud demonstration.
 //Replaced git and podman prereqs with the tooling dependencies page


### PR DESCRIPTION
The console.redhat.com site currently has no top-level OpenShift link or menu.