### PR TITLE
Rename google group

### DIFF
--- a/content/patterns/ansible-edge-gitops/_index.md
+++ b/content/patterns/ansible-edge-gitops/_index.md
@@ -15,7 +15,7 @@ aliases: /ansible-edge-gitops/
 pattern_logo: ansible-edge.png
 links:
   install: getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/ansible-edge-gitops/issues
 ci: aegitops
 ---

--- a/content/patterns/ansible-edge-gitops/ansible-automation-platform.md
+++ b/content/patterns/ansible-edge-gitops/ansible-automation-platform.md
@@ -189,5 +189,5 @@ This does the work of provisioning the kiosk, which configures kiosk mode, and a
 
 # Next Steps
 
-## [Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns)
+## [Help & Feedback](https://groups.google.com/g/validatedpatterns)
 ## [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues)

--- a/content/patterns/ansible-edge-gitops/getting-started.md
+++ b/content/patterns/ansible-edge-gitops/getting-started.md
@@ -232,5 +232,5 @@ As part of this pattern HashiCorp Vault has been installed. Refer to the section
 
 # Next Steps
 
-## [Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns)
+## [Help & Feedback](https://groups.google.com/g/validatedpatterns)
 ## [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues)

--- a/content/patterns/ansible-edge-gitops/ideas-for-customization.md
+++ b/content/patterns/ansible-edge-gitops/ideas-for-customization.md
@@ -264,5 +264,5 @@ The reason this pattern ships with a script as it does instead of invoking the r
 
 # Next Steps
 
-## [Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns)
+## [Help & Feedback](https://groups.google.com/g/validatedpatterns)
 ## [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues)

--- a/content/patterns/ansible-edge-gitops/installation-details.md
+++ b/content/patterns/ansible-edge-gitops/installation-details.md
@@ -129,5 +129,5 @@ More details of the specifics of how AAP is configured are available [here](/ans
 
 # Next Steps
 
-## [Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns)
+## [Help & Feedback](https://groups.google.com/g/validatedpatterns)
 ## [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues)

--- a/content/patterns/ansible-edge-gitops/openshift-virtualization.md
+++ b/content/patterns/ansible-edge-gitops/openshift-virtualization.md
@@ -353,5 +353,5 @@ The [rhel8-kiosk-with-svc](https://github.com/validatedpatterns/ansible-edge-git
 
 # Next Steps
 
-## [Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns)
+## [Help & Feedback](https://groups.google.com/g/validatedpatterns)
 ## [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues)

--- a/content/patterns/devsecops/_index.md
+++ b/content/patterns/devsecops/_index.md
@@ -15,7 +15,7 @@ aliases: /devsecops/
 # pattern_logo: devsecops.png
 links:
   install: getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/multicluster-devsecops/issues
 ci: devsecops
 ---

--- a/content/patterns/devsecops/getting-started.md
+++ b/content/patterns/devsecops/getting-started.md
@@ -263,7 +263,7 @@ Advanced Cluster Security needs to be integrated with Quay Enterprise registry. 
 
 # Next Steps
 
-[Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Help & Feedback](https://groups.google.com/g/validatedpatterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Report Bugs](https://github.com/validatedpatterns/multicluster-devsecops/issues){: .btn .btn-red .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 Once the hub has been setup correctly and confirmed to be working, you can:

--- a/content/patterns/industrial-edge/_index.md
+++ b/content/patterns/industrial-edge/_index.md
@@ -16,7 +16,7 @@ pattern_logo: industrial-edge.png
 links:
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/architecturedetail?ppid=26
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/industrial-edge/issues
 ci: manuela
 ---

--- a/content/patterns/industrial-edge/getting-started.md
+++ b/content/patterns/industrial-edge/getting-started.md
@@ -227,7 +227,7 @@ For installation tooling dependencies, see [Patterns quick start]({{< ref "/cont
 
 ## Next Steps
 
-[Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Help & Feedback](https://groups.google.com/g/validatedpatterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Report Bugs](https://github.com/validatedpatterns/industrial-edge/issues){: .btn .btn-red .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 Once the data center has been setup correctly and confirmed to be working, you can:

--- a/content/patterns/industrial-edge/ideas-for-customization.md
+++ b/content/patterns/industrial-edge/ideas-for-customization.md
@@ -61,5 +61,5 @@ The idea is that this pattern can be used for other use cases keeping the main c
 
 What ideas for customization do you have? Can you use this pattern for other use cases?  Let us know through our feedback link below.
 
-[Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Help & Feedback](https://groups.google.com/g/validatedpatterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Report Bugs](https://github.com/validatedpatterns/ansible-edge-gitops/issues){: .btn .btn-red .fs-5 .mb-4 .mb-md-0 .mr-2 }

--- a/content/patterns/multicloud-gitops-Portworx/_index.md
+++ b/content/patterns/multicloud-gitops-Portworx/_index.md
@@ -13,7 +13,7 @@ aliases: /multicloud-gitops-Portworx/
 pattern_logo: multicloud-gitops-Portworx.png
 links:
   install: getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/medical-diagnosis/issues
 # ci: mcgitopspxe
 ---

--- a/content/patterns/multicloud-gitops-Portworx/getting-started.md
+++ b/content/patterns/multicloud-gitops-Portworx/getting-started.md
@@ -106,5 +106,5 @@ After the management hub is set up and works correctly, attach one or more manag
 For instructions on deploying the edge, refer to [Managed Cluster Sites](https://validatedpatterns.io/patterns/multicloud-gitops-portworx/managed-cluster/).
 
 >Contribute to this pattern:
-{{% button text="Help & Feedback" url="https://groups.google.com/g/hybrid-cloud-patterns" %}}
+{{% button text="Help & Feedback" url="https://groups.google.com/g/validatedpatterns" %}}
 {{% button text="Report Bugs" url="https://github.com/portworx/rh-multicloud-gitops-pxe/issues" color-class="btn-red" %}}

--- a/content/patterns/multicloud-gitops-Portworx/ideas-for-customization.md
+++ b/content/patterns/multicloud-gitops-Portworx/ideas-for-customization.md
@@ -25,5 +25,5 @@ Another idea, after splitting the charts, could be to implement a small Rest API
 In the end the possibilities to tweak this pattern are endless. Do let us know if you have an awesome idea that you'd like to add
 
 >Contribute to this pattern:
-[Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Help & Feedback](https://groups.google.com/g/validatedpatterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Report Bugs](https://github.com/validatedpatterns/multicloud-gitops/issues){: .btn .btn-red .fs-5 .mb-4 .mb-md-0 .mr-2 }

--- a/content/patterns/retail/_index.md
+++ b/content/patterns/retail/_index.md
@@ -14,7 +14,7 @@ aliases: /retail/
 # pattern_logo: retail.png
 links:
   install: getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/retail/issues
 # uncomment once this exists
 # ci: retail

--- a/content/patterns/retail/getting-started.md
+++ b/content/patterns/retail/getting-started.md
@@ -164,5 +164,5 @@ Clicking on the respective Kafdrop links will go to a Kafdrop instance that allo
 
 ## Next Steps
 
-[Help & Feedback](https://groups.google.com/g/hybrid-cloud-patterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Help & Feedback](https://groups.google.com/g/validatedpatterns){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Report Bugs](https://github.com/validatedpatterns/retail/issues){: .btn .btn-red .fs-5 .mb-4 .mb-md-0 .mr-2 }


### PR DESCRIPTION
Since https://groups.google.com/g/validatedpatterns is the new thing and
the old group https://groups.google.com/g/hybrid-cloud-patterns returns
"Content unavailable", let's do the switch now
