### PR TITLE
Removing the red boarder for .err in examples

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -664,9 +664,9 @@ b.conum * {
   color: #408080;
   font-style: italic;
 } /* Comment */
-.highlight .err {
+/* .highlight .err {
   border: 1px solid #ff0000;
-} /* Error */
+} Error */
 .highlight .k {
   color: #008000;
   font-weight: bold;


### PR DESCRIPTION
The err highlighting is messing with your examples and makes things look a little weird. Removing it.