### PR TITLE
Rename group everywhere

### DIFF
--- a/archetypes/pattern/_index.adoc
+++ b/archetypes/pattern/_index.adoc
@@ -13,7 +13,7 @@ industries:
 links:
   install:
   arch:
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs:
 # The following parameters are only used for validated patterns. Do not uncomment them unless your pattern is validated.
 # validated:

--- a/content/patterns/emerging-disease-detection/_index.adoc
+++ b/content/patterns/emerging-disease-detection/_index.adoc
@@ -15,7 +15,7 @@ aliases: /emerging-disease-detection/
 links:
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/architecturedetail?ppid=6
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/emerging-disease-detection/issues
 ci: edd
 ---

--- a/content/patterns/emerging-disease-detection/getting-started.adoc
+++ b/content/patterns/emerging-disease-detection/getting-started.adoc
@@ -225,5 +225,5 @@ TO-DO: Describe how to examine the various parts of the Sepsis application
 
 = Next Steps
 
-link:https://groups.google.com/g/hybrid-cloud-patterns[Help & Feedback]
+link:https://groups.google.com/g/validatedpatterns[Help & Feedback]
 link:https://github.com/validatedpatterns/emerging-disease-detection/issues[Report Bugs]

--- a/content/patterns/medical-diagnosis/_index.adoc
+++ b/content/patterns/medical-diagnosis/_index.adoc
@@ -14,7 +14,7 @@ pattern_logo: medical-diagnosis.png
 links:
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/architecturedetail?ppid=6
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/medical-diagnosis/issues
 ci: medicaldiag
 ---

--- a/content/patterns/multicloud-gitops/_index.adoc
+++ b/content/patterns/multicloud-gitops/_index.adoc
@@ -13,7 +13,7 @@ pattern_logo: multicloud-gitops.png
 links:
   install: mcg-getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/8-hybrid-multicloud-management-with-gitops
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/multicloud-gitops/issues
 ci: mcgitops
 ---

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -45,7 +45,7 @@
                         -->
                             <li>
                                 <i class="prefooter-icon fas fa-envelope"></i>
-                                <a href="https://groups.google.com/g/hybrid-cloud-patterns" class="footer-link" target="top" aria-label="Join the Validated Patterns mailing list">Mailing list</a>
+                                <a href="https://groups.google.com/g/validatedpatterns" class="footer-link" target="top" aria-label="Join the Validated Patterns mailing list">Mailing list</a>
                             </li>
                         </ul>
                     </nav>


### PR DESCRIPTION
I think there was a previous attempt, but not all places were done?

Anyhow, the correct group name is:
https://groups.google.com/g/validatedpatterns

Closes #346
