### PR TITLE
Added the common attributes file to all assembly/main adoc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Validated Patterns documentation site
 
-This project contains the new proof-of-concept documentation site for validatedpatterns.io
+This project contains the new proof-of-concept documentation site for [validatedpatterns.io](validatedpatterns.io).
 
-You can build this site using [Hugo](https://gohugo.io/).
+Use a container image to build the Validated Patterns documentation, locally. See [Preview the documentation using a container image](https://validatedpatterns.io/contribute/contribute-to-docs/#_preview_the_documentation_using_a_container_image).
+
+Alternatively, you can build this site using [Hugo](https://gohugo.io/).
 
 ## Install Hugo
 

--- a/content/contribute/background-on-pattern-development.adoc
+++ b/content/contribute/background-on-pattern-development.adoc
@@ -8,6 +8,7 @@ aliases: /background-on-pattern-development/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 == Introduction
 

--- a/content/contribute/contribute-to-docs.adoc
+++ b/content/contribute/contribute-to-docs.adoc
@@ -6,6 +6,8 @@ weight: 10
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 //Use the Contributor's guide to learn about ways to contribute to the Validated Patterns, to understand the prerequisites and toolchain required for contribution, and to follow some basic documentation style and structure guidelines.
 

--- a/content/contribute/creating-a-pattern.adoc
+++ b/content/contribute/creating-a-pattern.adoc
@@ -8,6 +8,7 @@ aliases: /creating-a-pattern/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 The validated patterns community has relied on existing architectures that have been successfully deployed in an enterprise. The architecture itself is a best practice in assembling technologies and projects to provide a working solution. How that solution is deployed and managed is a different matter. It may have evolved over time and may have grown in its deployment such that ongoing maintenance is not sustainable.
 

--- a/content/contribute/extending-a-pattern.adoc
+++ b/content/contribute/extending-a-pattern.adoc
@@ -8,6 +8,7 @@ aliases: /extending-a-pattern/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 == Introduction to extending a pattern using a fork
 

--- a/content/contribute/structure.adoc
+++ b/content/contribute/structure.adoc
@@ -10,6 +10,7 @@ aliases: /building-vps/structure/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 == Framework fundamentals
 

--- a/content/learn/about.adoc
+++ b/content/learn/about.adoc
@@ -5,6 +5,9 @@ weight: 10
 ---
 :toc:
 
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+
 Validated Patterns and upstream Community Patterns are a natural progression from reference architectures with additional value. Here is a brief video to explain what patterns are all about:
 
 image::https://img.youtube.com/vi/lI8TurakeG4/0.jpg[patterns-intro-video,link=https://www.youtube.com/watch?v=lI8TurakeG4]

--- a/content/learn/importing-a-cluster.adoc
+++ b/content/learn/importing-a-cluster.adoc
@@ -8,6 +8,8 @@ aliases: /learn/importing-a-cluster/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 [id="importing-a-cluster"]
 == Importing a managed cluster

--- a/content/learn/infrastructure.adoc
+++ b/content/learn/infrastructure.adoc
@@ -6,6 +6,8 @@ aliases: /infrastructure/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 [id="background"]
 == Background

--- a/content/learn/ocp-cluster-general-sizing.adoc
+++ b/content/learn/ocp-cluster-general-sizing.adoc
@@ -8,6 +8,8 @@ aliases: /infrastructure/ocp-cluster-general-sizing/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = OpenShift General Sizing
 

--- a/content/learn/quickstart.adoc
+++ b/content/learn/quickstart.adoc
@@ -6,6 +6,8 @@ weight: 20
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 == Patterns quick start
 

--- a/content/learn/rhel-for-edge-general-sizing.adoc
+++ b/content/learn/rhel-for-edge-general-sizing.adoc
@@ -8,6 +8,8 @@ aliases: /infrastructure/rhel-for-edge-general-sizing/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = RHEL for Edge General Sizing
 

--- a/content/learn/secrets.adoc
+++ b/content/learn/secrets.adoc
@@ -6,6 +6,8 @@ aliases: /secrets/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = Infrastructure
 

--- a/content/learn/validated.adoc
+++ b/content/learn/validated.adoc
@@ -8,6 +8,8 @@ aliases: /requirements/validated/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = Validated Pattern Requirements
 

--- a/content/learn/vault.adoc
+++ b/content/learn/vault.adoc
@@ -8,6 +8,8 @@ aliases: /secrets/vault/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = Deploying HashiCorp Vault in a validated pattern
 

--- a/content/learn/workflow.adoc
+++ b/content/learn/workflow.adoc
@@ -6,6 +6,8 @@ aliases: /workflow/
 ---
 
 :toc:
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 = Workflow
 

--- a/content/patterns/emerging-disease-detection/_index.adoc
+++ b/content/patterns/emerging-disease-detection/_index.adoc
@@ -26,6 +26,7 @@ contributor:
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/edd-about-emerging-disease-detection.adoc[leveloffset=+1]
 

--- a/content/patterns/emerging-disease-detection/edd-getting-started.adoc
+++ b/content/patterns/emerging-disease-detection/edd-getting-started.adoc
@@ -6,12 +6,9 @@ aliases: /emerging-disease-detection/getting-started/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/edd-deploying-edd-pattern.adoc[leveloffset=1]
 
 include::modules/edd-using-edd-pattern.adoc[leveloffset=1]
 
-= Next Steps
-
-link:https://groups.google.com/g/hybrid-cloud-patterns[Help & Feedback]
-link:https://github.com/validatedpatterns/emerging-disease-detection/issues[Report Bugs]

--- a/content/patterns/hypershift/_index.adoc
+++ b/content/patterns/hypershift/_index.adoc
@@ -12,7 +12,7 @@ industries:
 aliases: /hypershift/
 pattern_logo: medical-diagnosis.png
 links:
- 
+
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/hypershift/issues
 ci: hypershift
@@ -36,9 +36,9 @@ This pattern simplifies the deployment of an {hcp} or hosted control plane clust
 Workflow::
 
 * Install multicluster engine for Kubernetes Operator
-* Create an instance of the `MultiClusterEngine` to enable `hypershift`, which is a [technology preview feature](https://access.redhat.com/support/offerings/techpreview).
+* Create an instance of the `MultiClusterEngine` to enable `hypershift`, which is a link:https://access.redhat.com/support/offerings/techpreview[technology preview feature].
 * Install the AWS Controllers for Kubernetes - Amazon S3 Operator
-* Create an S3 bucket that hosted control plane will use for OpenID Connect (OIDC) 
+* Create an S3 bucket that hosted control plane will use for OpenID Connect (OIDC)
 * Create a buildconfig and imagestream that provide the HyperShift cli (`hypershift`) as an imagestream to be used in further automation if desired.
 
 //This pipeline is showcased link:https://www.youtube.com/watch?v=zja83FVsm14[in this video].
@@ -59,8 +59,8 @@ The {hcp-pattern} uses the following products and technologies:
 
 * {rh-ocp} for container orchestration
 * {rh-gitops}, a GitOps continuous delivery (CD) solution
-* {rh-mce}, the multicluster-engine provider
-* {ack-s3}, a S3 storage controller
+* The {rh-mce} Operator, the multicluster-engine provider
+* {ack-s3-op}, an S3 storage controller
 
 // All commented out by jrickard
 //== Recorded demo

--- a/content/patterns/multicloud-gitops/_index.adoc
+++ b/content/patterns/multicloud-gitops/_index.adoc
@@ -20,6 +20,7 @@ ci: mcgitops
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/mcg-about-multicloud-gitops.adoc[leveloffset=+1]
 

--- a/content/patterns/multicloud-gitops/mcg-cluster-sizing.adoc
+++ b/content/patterns/multicloud-gitops/mcg-cluster-sizing.adoc
@@ -7,6 +7,7 @@ aliases: /multicloud-gitops/mcg-cluster-sizing/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/mcg-about-cluster-sizing.adoc[leveloffset=+1]
 

--- a/content/patterns/multicloud-gitops/mcg-getting-started.adoc
+++ b/content/patterns/multicloud-gitops/mcg-getting-started.adoc
@@ -7,6 +7,7 @@ aliases: /multicloud-gitops/mcg-getting-started/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/mcg-deploying-mcg-pattern.adoc[leveloffset=1]
 

--- a/content/patterns/multicloud-gitops/mcg-ideas-for-customization.adoc
+++ b/content/patterns/multicloud-gitops/mcg-ideas-for-customization.adoc
@@ -7,6 +7,7 @@ aliases: /multicloud-gitops/mcg-ideas-for-customization/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 //leaving this here on purpose to test H1 headings in assemblies and it's impact of TOC
 = Ideas for customization

--- a/content/patterns/multicloud-gitops/mcg-imperative-actions.adoc
+++ b/content/patterns/multicloud-gitops/mcg-imperative-actions.adoc
@@ -7,5 +7,6 @@ aliases: /multicloud-gitops/mcg-imperative-actions/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 include::modules/mcg-using-imperative-actions.adoc[leveloffset=+1]

--- a/content/patterns/multicloud-gitops/mcg-managed-cluster.adoc
+++ b/content/patterns/multicloud-gitops/mcg-managed-cluster.adoc
@@ -7,6 +7,7 @@ aliases: /multicloud-gitops/mcg-managed-cluster/
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
 
 //leaving this here on purpose to test H1 headings (with ID) in assemblies and it's impact of TOC
 [id="attach-managed-cluster"]

--- a/modules/mcg-about-cluster-sizing.adoc
+++ b/modules/mcg-about-cluster-sizing.adoc
@@ -5,7 +5,11 @@
 [id="about-openshift-cluster-sizing-mcg"]
 = About OpenShift cluster sizing for the Multicloud GitOps Pattern
 
-For information on minimum hardware requirements for an OpenShift cluster, refer to the {ocp} documentation for link:https://docs.openshift.com/container-platform/3.11/install/prerequisites.html#hardware[System and environment requirements].
+The minimum requirements for an {ocp} cluster depend on your installation platform, for example:
+
+* For AWS, see link:https://docs.openshift.com/container-platform/4.13/installing/installing_aws/preparing-to-install-on-aws.html#requirements-for-installing-ocp-on-aws[Installing {ocp} on AWS].
+
+* For bare-metal, see link:https://docs.openshift.com/container-platform/4.13/installing/installing_bare_metal/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal[Installing {ocp} on bare metal].
 
 To understand cluster sizing requirements for the Multicloud GitOps pattern, consider the following components that the Multicloud GitOps pattern deploys on the datacenter or the hub OpenShift cluster:
 


### PR DESCRIPTION
Fixes #335 #336 and #364 

This PR also add the common attributes file (`modules/comm-attributes.adoc`) to all assembly/main adoc files under the Learn, Contribute, and applicable Patterns content types.  It also includes some minor fixes to the recently merged #365 

Issue: https://issues.redhat.com/browse/TELCODOCS-1620