### PR TITLE
Fixed link for the maintained pattern

### DIFF
--- a/content/learn/maintained.adoc
+++ b/content/learn/maintained.adoc
@@ -5,7 +5,6 @@ menu:
 title: Validated Patterns - Maintained tier
 weight: 45
 aliases: /requirements/maintained/
-aliases: /requirements/validated/
 ---
 
 :toc:


### PR DESCRIPTION
fixes a broken link in #352 

It seems that having two aliases was causing the fink to fail. When i removed the older one (that directed to the Validated Pattern page) the link to the maintained one got resolved