### PR TITLE
Increasing the timeout for 'hugo serve'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ title: Validated Patterns
 theme: "patternfly"
 summaryLength: 20
 paginate: 6
+timeout: 300
 params:
   site_logo: /images/validated-patterns.png
 security:


### PR DESCRIPTION
We had some timeout error when running 'make serve' locally. Have increased the timeout from 30sec to 300sec.