### PR TITLE
Portfolio2Solution Architecture Display update

### DIFF
--- a/layouts/partials/links.html
+++ b/layouts/partials/links.html
@@ -14,7 +14,7 @@
   <span class="pf-c-list__item-icon">
     <i class="fa-solid fa-layer-group"></i>
   </span>
-  <a href="{{ .Params.links.arch }}" class="">Portfolio Architecture</a>
+  <a href="{{ .Params.links.arch }}" class="">Solution Architecture</a>
 </li>
 {{ end }}
 {{ if (isset .Params.links "help") }}


### PR DESCRIPTION
The portfolio architecture team rebranded earlier this year and would like to have the patterns display a name that reflects their organization. This update will change the way the `arch` module renders on the web. Instead of showing `Portfolio Architecture` it will show `Solution Architecture`
