### PR TITLE
Align htmltest versions with homepage-container

### DIFF
--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -12,14 +12,17 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.0.7'
 
-      - run: gem install asciidoctor
+      - name: Install build dependencies
+        run: |
+          gem install asciidoctor -v 2.0.23
+          gem install rouge -v 4.3.0
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.133.1'
           extended: true
 
       - name: Build


### PR DESCRIPTION
Align the htmltest versions with what is found in the homepage-container, with the hope that this will resolve the test issues once and for all.