### PR TITLE
Added Workshop to main nav menu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,9 @@ mediaTypes:
 outputFormats:
   patterns:
     mediatype: application/json
+
+menus:
+  main:
+    - name: Workshop
+      url: https://play.validatedpatterns.io
+      weight: 25


### PR DESCRIPTION
@day0hero found out how to add menu items without needing to hardcode it into the templates:

https://gohugo.io/content-management/menus/

Basically there are two ways to add menu items:

1. Add the menu to the `menus` param in the front matter of a top-level page, and then it automatically adds the item to the menu
2. Manually define the menu items in the config.yaml file

For external links, you need to do method 2. 

Luckily, you can mix both methods 1 and 2 together, so we can keep our existing structure, and just define an additional menu item. Have added the workshop after the Learn item. Down the track, we might look at migrating the content from the workshop site to the vp site. But for the moment, this should be a good temp solution.

I'll close #459 in favor of this PR, but give me a lgtm if everything looks good on your end.