### PR TITLE
[TEST] Use xref instead of link

### DIFF
--- a/content/contribute/background-on-pattern-development.adoc
+++ b/content/contribute/background-on-pattern-development.adoc
@@ -10,6 +10,7 @@ aliases: /background-on-pattern-development/
 :_content-type: ASSEMBLY
 include::modules/comm-attributes.adoc[]
 
+[id="introduction_background-on-pattern-development"]
 == Introduction
 
 This section provides details on how to create a new pattern using the validated patterns framework. Creating a new pattern might start from scratch or it may start from an existing deployment that would benefit from a repeatable framework based on GitOps.

--- a/content/contribute/creating-a-pattern.adoc
+++ b/content/contribute/creating-a-pattern.adoc
@@ -20,7 +20,7 @@ So how do you take a current application workload and move it to the Validated P
 
 == Prerequisites
 
-Please make sure you have read the link:/background-on-pattern-development/[background section], including the link:/ocp-framework/structure/[structure section].
+Please make sure you have read the xref:introduction_background-on-pattern-development[background section], including the xref:openshift-framework-fundamentals_ocp-framework-structure[structure section].
 
 == You're probably not starting from scratch
 

--- a/content/learn/validated_patterns_frameworks.adoc
+++ b/content/learn/validated_patterns_frameworks.adoc
@@ -10,9 +10,10 @@ aliases: /validated-patterns-frameworks/
 :_content-type: ASSEMBLY
 include::modules/comm-attributes.adoc[]
 
+[id="validated-patterns-frameworks-introduction"]
 == Introduction
 
-Validated patterns provides two frameworks to deploy applications: the OpenShift-based Validated Patterns framework and the Ansible GitOps Framework (AGOF). 
+Validated patterns provides two frameworks to deploy applications: the OpenShift-based Validated Patterns framework and the Ansible GitOps Framework (AGOF).
 
 The OpenShift-based validated patterns framework is the most common method for deploying applications and infrastructure on the OpenShift Container Platform. It offers a set of predefined configurations and patterns that follow best practices and are validated by Red Hat.
 

--- a/content/learn/vp_openshift_framework.adoc
+++ b/content/learn/vp_openshift_framework.adoc
@@ -12,6 +12,7 @@ aliases: /ocp-framework/structure/
 :_content-type: ASSEMBLY
 include::modules/comm-attributes.adoc[]
 
+[id="openshift-framework-fundamentals_ocp-framework-structure"]
 == OpenShift framework fundamentals
 
 The OpenShift validated patterns framework uses https://docs.openshift.com/container-platform/latest/cicd/gitops/understanding-openshift-gitops.html[OpenShift GitOps] (ArgoCD) as the primary driver for deploying patterns and keeping them up to date. Validated patterns use Helm charts as the primary artifacts for GitOps. https://helm.sh/[Helm charts] provide a mechanism for templating that is powerful when building repeatable, automated deployments across different deployment environments (i.e. clouds, data-centers, edge, etc.)


### PR DESCRIPTION
Use xref to refer to internal content vs using canonical links to try
passing htmltest before full commit.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
