### PR TITLE
rag llm cluster sizing

### DIFF
--- a/content/patterns/industrial-edge/cluster-sizing.adoc
+++ b/content/patterns/industrial-edge/cluster-sizing.adoc
@@ -1,7 +1,7 @@
 ---
 title: Cluster sizing
 weight: 50
-aliases: /industrial-edge/mcg-cluster-sizing/
+aliases: /industrial-edge/cluster-sizing/
 ---
 
 :toc:

--- a/content/patterns/rag-llm-gitops/cluster-sizing.adoc
+++ b/content/patterns/rag-llm-gitops/cluster-sizing.adoc
@@ -1,0 +1,13 @@
+---
+title: Cluster sizing
+weight: 50
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+include::modules/comm-attributes.adoc[]
+include::modules/rag-llm-gitops/metadata-rag-llm-gitops.adoc[]
+
+include::modules/cluster-sizing-template.adoc[]


### PR DESCRIPTION
- **Add cluster sizing page for rag-llm-gitops**
- **Drop wrong alias from IE cluster sizing page**
