### PR TITLE
Corrected the example in clustergroup values files

### DIFF
--- a/modules/subscriptions-configuration-in-a-clustergroup.adoc
+++ b/modules/subscriptions-configuration-in-a-clustergroup.adoc
@@ -89,9 +89,6 @@ subscriptions:
 [source,yaml]
 ----
 subscriptions:
-    acm:
-      name: advanced-cluster-management
-      namespace: open-clustsubscriptions:
     openshift-data-foundation:
       disabled: true
 
@@ -100,8 +97,7 @@ subscriptions:
       namespace: portworx
       channel: stable
       source: certified-operators
-er-management
-      channel: release-2.10
+
 ----
 
 In this example, the values file is intended to override the default settings in the main `values-hub.yaml`. Consequently, the `openshift-data-foundation` application is overridden and disabled, while the `portworx` application is added.


### PR DESCRIPTION
Corrected the example in the sub-section titled Subscriptions for Ansible Edge GitOps (demonstrating disable and override)
Issue: https://issues.redhat.com/browse/TELCODOCS-2179

Link to docs preview: http://537.docs-pr.validatedpatterns.io/