### PR TITLE
minor medical diagnosis pattern docs fixes

### DIFF
--- a/content/patterns/medical-diagnosis/demo-script.adoc
+++ b/content/patterns/medical-diagnosis/demo-script.adoc
@@ -29,7 +29,7 @@ We simulate the function of the remote medical facility with an application call
 
 The Grafana dashboard offers a visual representation of the AI/ML workflow, including CPU and memory metrics for the pod running the risk assessment application. Additionally, it displays a graphical overview of the AI/ML workflow, illustrating the images being generated at the remote medical facility. 
 
-This showcase application is deployed with self-signed certificates, which are considered untrusted by most browsers. If valid certificates have not been provisioned for your OpenShift cluster, you will need to manually accept the untrusted certificates by following these steps:
+This showcase application is deployed with self-signed certificates, which are considered untrusted by most browsers. If valid certificates have not been provisioned for your OpenShift cluster, you will need to manually accept the untrusted certificates using the process below.
 
 . Accept the SSL certificates on the browser for the dashboard. In the {ocp} web console,  go to the *Networking* > *Routes* for *All Projects*. Click the URL for the `s3-rgw`.
 +
@@ -39,11 +39,9 @@ Ensure that you see XML and not the access denied error message.
 +
 image::../../images/medical-edge/storage-rgw-route.png[link="/images/medical-edge/storage-rgw-route.png"]
 
-. While still looking at *Routes*, change the project to `xraylab-1`. Click the URL for the `image-server` and ensure that you do not see an access denied error message. You should see a `Hello world` message.
+This showcase application does not have access to a x-ray machine hanging around that we can use for this demo, so one is emulated by creating an S3 bucket and hosting the x-ray images within it. In the "real world" an x-ray would be taken at an edge medical facility and then uploaded to an OpenShift Data Foundations (ODF) S3 compatible bucket in the Core Hospital, triggering the AI/ML workflow.
 
-This showcase application does not have access to a x-ray machine hanging around that we can use for this demo, so one is emulated by creating an s3 bucket and hosting the x-ray images within it. In the "real world" an x-ray would be taken at an edge medical facility and then uploaded to an OpenShift Data Foundations (ODF) S3 compatible bucket in the Core Hospital, triggering the AI/ML workflow.
-
-To emulate the edge medical facility we use an application called `image-generator` which when scaled up will download the x-rays from s3 and put them in an ODF s3 bucket in the cluster, triggering the AI/ML workflow. 
+To emulate the edge medical facility we use an application called `image-generator` which when scaled up will download the x-rays from S3 and put them in an ODF S3 bucket in the cluster, triggering the AI/ML workflow. 
 
 Turn on the image file flow. There are couple of ways to go about this.
 

--- a/content/patterns/medical-diagnosis/getting-started.adoc
+++ b/content/patterns/medical-diagnosis/getting-started.adoc
@@ -63,7 +63,7 @@ For the official documentation on creating the buckets on AWS and other cloud pr
 == Utilities
 //AI: Update the use of community and VP post naming tier update
 
-Follow this procedure to use the scripts provided in the link:https://github.com/validatedpatterns/utilities[utilities] repo to configure and S3 bucket in your AWS environment for the x-ray images.
+Follow this procedure to use the scripts provided in the link:https://github.com/validatedpatterns/utilities[utilities] repo to configure an S3 bucket in your AWS environment for the x-ray images.
 
 .Procedure
 
@@ -383,7 +383,7 @@ The {med-pattern} is successfully installed in the relevant namespace.
 
 ** *Name* - A name for the pattern deployment that is used in the projects that you created.
 ** *Labels* - Apply any other labels you might need for deploying this pattern.
-** *Cluster Group Name* - Select a cluster group name to identify the type of cluster where this pattern is being deployed. For example, if you are deploying the {ie-pattern}, the cluster group name is `datacenter`. If you are deploying the {mcg-pattern}, the cluster group name is `hub`.
+** *Cluster Group Name* - Select a cluster group name to identify the type of cluster where this pattern is being deployed. For the {med-pattern}, `hub` is correct unless you updated it in `values-global.yaml` above.
 +
 To know the cluster group name for the patterns that you want to deploy, check the relevant pattern-specific requirements.
 . Expand the *Git Config* section to reveal the options and enter the required information.
@@ -394,7 +394,7 @@ To know the cluster group name for the patterns that you want to deploy, check t
 +
 [NOTE]
 ====
-A pop-up error with the message "Oh no! Something went wrong." might appear during the process. This error can be safely disregarded as it does not impact the installation of the Multicloud GitOps pattern. Use the Hub ArgoCD UI, accessible through the nines menu, to check the status of ArgoCD instances, which will display states such as progressing, healthy, and so on, for each managed application. The Cluster ArgoCD provides detailed status on each application, as defined in the clustergroup values file.
+A pop-up error with the message "Oh no! Something went wrong." might appear during the process. This error can be safely disregarded as it does not impact the installation of the {med-pattern}. Use the Hub ArgoCD UI, accessible through the nines menu, to check the status of ArgoCD instances, which will display states such as progressing, healthy, and so on, for each managed application. The Cluster ArgoCD provides detailed status on each application, as defined in the clustergroup values file.
 ====
 
 The {rh-gitops} Operator displays in list of *Installed Operators*. The {rh-gitops} Operator installs the remaining assets and artifacts for this pattern. To view the installation of these assets and artifacts, such as {rh-rhacm-first}, ensure that you switch to *Project:All Projects*.


### PR DESCRIPTION
Specifically:
- remove reference to `image-server`, which is no longer part of this pattern
- make sure docs correctly refer to this pattern, rather than the MCG pattern
- consistently capitalize 'S3'

There is one remaining change, which will be part of a future PR, to fix and make optional the instructions for setting up the S3 bucket. Images from the bucket I created following the directions ultimately failed to be processed even though it seemed like Ceph was able to copy them just fine.