### PR TITLE
Enabling URL parameters for categories and filter types

### DIFF
--- a/layouts/partials/patterns-browser.html
+++ b/layouts/partials/patterns-browser.html
@@ -2,7 +2,7 @@
   <div class="pf-c-page__sidebar-body">
     <div class="pf-l-flex filter-title-div">
       <span class="pf-c-title pf-m-md filter-title pf-l-flex__item pf-m-grow">Filter by</span>
-    <!--  <span class="pf-l-flex__item reset-title">Reset filters</span> -->
+      <span class="pf-l-flex__item reset-title"><a id="clear_filters" href="#" onclick="clearFilters();return false;">Clear filters</a></span>
     </div>
         {{ partial "menu-patterns-browser.html" . }}
   </div>


### PR DESCRIPTION
This commit provides a way to set a permanent URL string for a filtered view on the patterns browser. It stores both the category (tier, industries, etc) and type (and / or) as URL params.

Notes:
- Default for the filter type is "and", so *_filter=and won't appear in the URL. Only *_filter=or will appear.