### PR TITLE
Adding variant functionality to patterns browser

### DIFF
--- a/content/patterns/medical-diagnosis-amx/_index.adoc
+++ b/content/patterns/medical-diagnosis-amx/_index.adoc
@@ -3,15 +3,16 @@ title: Intel AMX accelerated Medical Diagnosis
 date: 2023-10-10
 validated: false
 summary: This pattern is based on a demo implementation of an automated data pipeline for chest X-ray analysis previously developed by Red Hat. The pattern is modified to utilize Intel AMX feature.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat OpenShift Serverless
 - Red Hat OpenShift Data Foundation
-- Red Hat OpenShift Node Feature Discovery
-- 4th Gen Intel Xeon Scalable processors with Intel Advanced Matrix Extensions (Intel AMX)
+partners:
+- Intel
 industries:
 - medical
 aliases: /medical-diagnosis-amx/
+variant_of: medical-diagnosis
 pattern_logo: medical-diagnosis.png
 links:
   install: getting-started

--- a/content/patterns/multicloud-gitops-Portworx/_index.md
+++ b/content/patterns/multicloud-gitops-Portworx/_index.md
@@ -11,6 +11,7 @@ partners:
 industries:
 - General
 aliases: /multicloud-gitops-Portworx/
+variant_of: multicloud-gitops
 pattern_logo: multicloud-gitops-Portworx.png
 links:
   install: getting-started

--- a/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
@@ -3,15 +3,16 @@ title: Intel AMX accelerated Multicloud GitOps with Openshift AI
 date: 2024-02-27
 validated: false
 summary: This is extension of Multicloud GitOps pattern with Red Hat Openshift AI component to show the value of using Intel AMX.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
 - Red Hat Openshift AI
-- OpenVINO Toolkit Operator
-- 5th Gen Intel Xeon Scalable processors with Intel Advanced Matrix Extensions (Intel AMX)
+partners:
+- Intel
 industries:
 - General
 aliases: /multicloud-gitops-amx-rhoai/
+variant_of: multicloud-gitops
 # uncomment once this exists
 # pattern_logo: multicloud-gitops.png
 pattern_logo: amx-intel-ai.png
@@ -105,7 +106,7 @@ This solution also uses a variety of _observability tools_ including the Prometh
 // RHODS pattern description
 The basic {mcg-pattern} has been extended to highlight the *{intel-5th-gen-xeon-processors}* capabilities, offering developers a streamlined pathway to accelerate their workloads through the integration of cutting-edge *{intel-amx}*, providing efficiency and performance optimization in AI workloads.
 
-The basic pattern has been extended with two components: Openshift AI and OpenVINO Toolkit Operator. 
+The basic pattern has been extended with two components: Openshift AI and OpenVINO Toolkit Operator.
 
 * Openshift AI, serves as a robust AI/ML platform for the creation of AI-driven applications and provides a collaborative environment for data scientists and developers that helps to move easily from experiment to production. It offers Jupyter application with selection of notebook servers, equipped with pre-configured environments and necessary support and optimizations (such as CUDA, PyTorch, Tensorflow, HabanaAI, etc.).
 

--- a/content/patterns/multicloud-gitops-amx/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx/_index.adoc
@@ -3,14 +3,15 @@ title: Intel AMX accelerated Multicloud GitOps
 date: 2023-10-05
 validated: false
 summary: This is extension of Multicloud GitOps pattern with additional application to show the value of using Intel AMX.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
-- Red Hat Node Feature Discovery
-- 4th Gen Intel Xeon Scalable processors with Intel Advanced Matrix Extensions (Intel AMX)
+partners:
+- Intel
 industries:
 - General
 aliases: /multicloud-gitops-amx/
+variant_of: multicloud-gitops
 # uncomment once this exists
 # pattern_logo: multicloud-gitops.png
 pattern_logo: amx-intel-ai.png

--- a/content/patterns/multicloud-gitops-qat/_index.adoc
+++ b/content/patterns/multicloud-gitops-qat/_index.adoc
@@ -3,16 +3,15 @@ title: Intel QAT accelerated Multicloud GitOps
 date: 2023-10-05
 validated: false
 summary: This is extension of Multicloud GitOps pattern with additional application to show the value of using Intel QAT.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
-- Red Hat Node Feature Discovery
-- 4th Gen Intel Xeon Scalable processors with Intel QuickAssist Technology (Intel QAT)
-- Sail Operator (Istio Service Mesh)
-- Intel Device Plugin Operator
+partners:
+- Intel
 industries:
 - General
 aliases: /multicloud-gitops-qat/
+variant_of: multicloud-gitops
 # uncomment once this exists
 # pattern_logo: multicloud-gitops.png
 pattern_logo: intel-qat.png

--- a/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
@@ -3,15 +3,15 @@ title: Intel SGX protected application in Multicloud GitOps
 date: 2024-02-20
 validated: false
 summary: This is an extension of Multicloud GitOps pattern with additional application using Intel SGX.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
-- Red Hat Node Feature Discovery
-- Intel Device Plugins Operator
-- 5th Gen Intel Xeon Scalable processors with Intel Software Guard Extensions (Intel SGX)
+partners:
+- Intel
 industries:
 - General
 aliases: /multicloud-gitops-sgx-hello-world/
+variant_of: multicloud-gitops
 # uncomment once this exists
 # pattern_logo: multicloud-gitops.png
 pattern_logo: sgx-intel-ai.png
@@ -45,7 +45,7 @@ Based on the requirements of a specific implementation, certain details might di
 Background::
 Organizations are aiming to develop, deploy, and operate applications on an open hybrid cloud in a stable, simple, and secure way. This hybrid strategy includes multi-cloud deployments where workloads might be running on multiple clusters and on multiple clouds, private or public.
 This strategy requires an infrastructure-as-code approach: GitOps. GitOps uses Git repositories as a single source of truth to deliver infrastructure-as-code. Submitted code checks the continuous integration (CI) process, while the continuous delivery (CD) process checks and applies requirements for things like security, infrastructure-as-code, or any other boundaries set for the application framework. All changes to code are tracked, making updates easy while also providing version control should a rollback be needed.
-Moreover, organizations are looking for solutions that are secure for AI, ML, data processing etc. It is the case especially for cloud computing, which uses heavily multi-tenancy and multiple processes runs on single bare-metal machine and they do not know who might be their neighbors and what are their intentions.  
+Moreover, organizations are looking for solutions that are secure for AI, ML, data processing etc. It is the case especially for cloud computing, which uses heavily multi-tenancy and multiple processes runs on single bare-metal machine and they do not know who might be their neighbors and what are their intentions.
 Memory encryption technologies can protect well the data and separate application from other ones run on the same machine - it is possible using *{intel-5th-gen-xeon-processors}* with *Intel Software Guard Extensions*.
 
 [id="about-solution"]
@@ -190,7 +190,7 @@ NFD manages the detection of hardware features and configuration in an OpenShift
 
 In the logs of `hello-world-sgx` pod, there is an information that "Gramine is starting" and it executes the application by printing "HelloWorld!".
 
-This pattern demonstrates basic capabilities of running docker applications inside SGX enclaves. Based on this pattern other applications can be secured with {intel-sgx} and Gramine Shielded Containers in a similar way as presented here. 
+This pattern demonstrates basic capabilities of running docker applications inside SGX enclaves. Based on this pattern other applications can be secured with {intel-sgx} and Gramine Shielded Containers in a similar way as presented here.
 
 //figure 7 originally
 .Logs from `hello-world-sgx` pod

--- a/content/patterns/multicloud-gitops-sgx/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx/_index.adoc
@@ -3,15 +3,15 @@ title: Intel SGX protected Vault for Multicloud GitOps
 date: 2024-02-09
 validated: false
 summary: This is an extension of the Multicloud GitOps pattern with an additional application to show the value of using Intel SGX.
-products:
+rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
-- Red Hat Node Feature Discovery
-- Intel Device Plugins
-- 5th Gen Intel Xeon Scalable processors with Intel Security Guard Extensions (Intel SGX)
+partners:
+- Intel
 industries:
 - General
 aliases: /multicloud-gitops-sgx/
+variant_of: multicloud-gitops
 # uncomment once this exists
 # pattern_logo: multicloud-gitops.png
 pattern_logo: sgx-intel-ai.png

--- a/layouts/partials/menu-patterns-browser.html
+++ b/layouts/partials/menu-patterns-browser.html
@@ -7,13 +7,14 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="typeHeading">
           <button class="pf-c-accordion__toggle collapsed" title="Filter patterns by validation type" type="button" data-bs-toggle="collapse" data-bs-target="#collapseType" aria-expanded="false" aria-controls="collapseType">
-            Pattern Tiers
+            Pattern Tiers <span id="TiersItemsCounter"></span>
             <span class="pf-c-accordion__toggle-icon">
               <i class="fas fa-angle-down" aria-hidden="true"></i>
             </span>
             <span class="pf-c-accordion__toggle-icon">
               <i class="fas fa-angle-right" aria-hidden="true"></i>
             </span>
+
           </button>
         </h2>
         <div id="collapseType" class="pf-c-accordion__expanded-content collapse" aria-labelledby="typeHeading" data-bs-parent="#patternsAccordionNav">
@@ -32,7 +33,7 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="industriesHeading">
           <button class="pf-c-accordion__toggle collapsed" title="Filter patterns by industry" type="button" data-bs-toggle="collapse" data-bs-target="#collapseIndustries" aria-expanded="false" aria-controls="collapseIndustries">
-            Industries
+            Industries <span id="IndustriesItemsCounter"></span>
             <span class="pf-c-accordion__toggle-icon">
               <i class="fas fa-angle-right" aria-hidden="true"></i>
             </span>
@@ -56,7 +57,7 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="rhProductHeading">
           <button class="pf-c-accordion__toggle collapsed" title="Filter patterns by Red Hat product" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRhProducts" aria-expanded="false" aria-controls="collapseRhProducts">
-            Red Hat products
+            Red Hat products <span id="RhProductsItemsCounter"></span>
             <span class="pf-c-accordion__toggle-icon">
               <i class="fas fa-angle-right" aria-hidden="true"></i>
             </span>
@@ -80,7 +81,7 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="partnerHeading">
           <button class="pf-c-accordion__toggle collapsed" title="Filter patterns by partners" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePartners" aria-expanded="false" aria-controls="collapsePartners">
-            Partners
+            Partners <span id="PartnersItemsCounter"></span>
             <span class="pf-c-accordion__toggle-icon">
               <i class="fas fa-angle-right" aria-hidden="true"></i>
             </span>

--- a/layouts/partials/patterns-browser.html
+++ b/layouts/partials/patterns-browser.html
@@ -43,6 +43,8 @@
         </div>
         <div class="pf-l-stack__item pf-u-text-align-right pattern-count-style" id="pattern-counter">
         </div>
+        <div class="pf-l-stack__item pattern-count-style" id="variant-status">
+        </div>
         <div class="pf-l-stack__item" id="patternLoaderSpinner">
         </div>
         <div class="pf-l-stack__item">


### PR DESCRIPTION
This feature adds variants to the patterns browser. Here's how it works:

You can set the `variant_of` parameter to a parent pattern ID, which is the directory name for the pattern under `content/patterns` e.g. multicloud-gitops

![image](https://github.com/user-attachments/assets/5bf2f217-751a-443d-8ba8-ef81f2e1decc)

The parent pattern will have an indicator for how many variant patterns there are on the bottom-right of the respective card in the patterns browser.

![image](https://github.com/user-attachments/assets/a9e02162-eff5-4bb8-8b4d-948a906f3645)

You can click on this indicator to navigate to a filtered patterns browser for the that particular parent. The browser has a status indicator to let you know which parent pattern you filtering variants by, plus a link to return to the full patterns browser.

![image](https://github.com/user-attachments/assets/bef88a28-fd59-462a-b02c-e10558c36813)

The same filters and sorting methods that work with the full patterns browser also work for the filtered parent patterns browser.


