### PR TITLE
Update _index.md

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,4 +6,4 @@ title: "Validated Patterns"
 
 # Reference architectures with added value
 
-Validated Patterns are an evolution of how you deploy applications in a hybrid cloud. With a pattern, you can automatically deploy a full application stack through a GitOps-based framework. With this framework, you can create business-centric solutions while maintaining a level of Continuous Integration (CI) over your application. 
+Validated Patterns are an evolution of how you deploy applications in a hybrid cloud. With a pattern, you can automatically deploy a full application stack through a GitOps-based framework. With this framework, you can create business-centric use cases while maintaining a level of Continuous Integration (CI) over your application. 


### PR DESCRIPTION
In having others reference our main page description, I noticed that as much as we do not generally use the word solutions, it is on our front page of the website.  My proposal is to change the word solution with use case to avoid confusion.