### PR TITLE
Add Intel as partner for QnA; update Help links 

### DIFF
--- a/content/patterns/gaudi-rag-chat-qna/_index.adoc
+++ b/content/patterns/gaudi-rag-chat-qna/_index.adoc
@@ -9,13 +9,15 @@ rh_products:
 - Red Hat OpenShift AI
 - Red Hat OpenShift Serverless
 - Red Hat OpenShift Service Mesh
+partners:
+- Intel
 industries:
 - General
 aliases: /gaudi-rag-chat-qna/
 #pattern_logo: gaudi-rag-chat-qna.png
 links:
   install: gaudi-rag-chat-qna-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/
 ---
 :toc:

--- a/content/patterns/medical-diagnosis-amx/_index.adoc
+++ b/content/patterns/medical-diagnosis-amx/_index.adoc
@@ -17,7 +17,7 @@ pattern_logo: medical-diagnosis.png
 links:
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-medical-diagnosis/issues
 ---
 

--- a/content/patterns/mlops-fraud-detection/mfd-running-the-demo.adoc
+++ b/content/patterns/mlops-fraud-detection/mfd-running-the-demo.adoc
@@ -12,5 +12,5 @@ include::modules/mfd-using-mfd-demo.adoc[leveloffset=1]
 
 = Next Steps
 
-link:https://groups.google.com/g/hybrid-cloud-patterns[Help & Feedback]
+link:https://groups.google.com/g/validatedpatterns[Help & Feedback]
 link:https://github.com/validatedpatterns/mlops-fraud-detection/issues[Report Bugs]

--- a/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
@@ -18,7 +18,7 @@ variant_of: multicloud-gitops
 pattern_logo: amx-intel-ai.png
 links:
   install: mcg-amx-rhoai-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops/issues
 ---
 

--- a/content/patterns/multicloud-gitops-amx/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx/_index.adoc
@@ -17,7 +17,7 @@ variant_of: multicloud-gitops
 pattern_logo: amx-intel-ai.png
 links:
   install: mcg-amx-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops/issues
 ---
 

--- a/content/patterns/multicloud-gitops-qat/_index.adoc
+++ b/content/patterns/multicloud-gitops-qat/_index.adoc
@@ -17,7 +17,7 @@ variant_of: multicloud-gitops
 pattern_logo: intel-qat.png
 links:
   install: mcg-qat-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/qat-accelerated-istio/issues
 ---
 

--- a/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
@@ -17,7 +17,7 @@ variant_of: multicloud-gitops
 pattern_logo: sgx-intel-ai.png
 links:
   install: mcg-sgx-hello-world-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
 #  bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world//issues
 ---
 

--- a/content/patterns/multicloud-gitops-sgx/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx/_index.adoc
@@ -17,7 +17,7 @@ variant_of: multicloud-gitops
 pattern_logo: sgx-intel-ai.png
 links:
   install: mcg-sgx-getting-started
-  help: https://groups.google.com/g/hybrid-cloud-patterns
+  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-vault/issues
 ---
 


### PR DESCRIPTION
Add Intel as partner for QnA; update Help links to direct to the Validated Patterns Google group (in place of the old Hybrid Cloud Patterns group)