### PR TITLE
TELCODOCS-2337: Add GitHub repo links in pattern headers

### DIFF
--- a/content/patterns/amd-rag-chat-qna/_index.adoc
+++ b/content/patterns/amd-rag-chat-qna/_index.adoc
@@ -1,8 +1,8 @@
 ---
 title: OPEA Chat QnA accelerated with AMD Instinct
 date: 2025-05-01
-tier: sandbox
 validated: false
+tier: sandbox
 summary: This pattern aids with deployment of OPEA's Chat QnA RAG application, accelerated with AMD Instinct hardware.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -17,9 +17,10 @@ industries:
 aliases: /amd-rag-chat-qna/
 #pattern_logo: amd-rag-chat-qna.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/qna-chat-amd/
   install: amd-rag-chat-qna-getting-started
   help: https://groups.google.com/g/validatedpatterns
-  bugs: https://github.com/validatedpatterns-sandbox/
+  bugs: https://github.com/validatedpatterns-sandbox/qna-chat-amd/issues
 ---
 :toc:
 :imagesdir: /images

--- a/content/patterns/ansible-edge-gitops-kasten/_index.md
+++ b/content/patterns/ansible-edge-gitops-kasten/_index.md
@@ -16,6 +16,7 @@ industries:
 aliases: /ansible-edge-gitops-kasten/
 pattern_logo: veeam-kasten.png
 links:
+  github: https://github.com/validatedpatterns/ansible-edge-gitops
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/ansible-edge-gitops/issues

--- a/content/patterns/ansible-edge-gitops/_index.adoc
+++ b/content/patterns/ansible-edge-gitops/_index.adoc
@@ -14,6 +14,7 @@ industries:
 aliases: /ansible-edge-gitops/
 pattern_logo: ansible-edge.png
 links:
+  github: https://github.com/validatedpatterns/ansible-edge-gitops/
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/ansible-edge-gitops/issues

--- a/content/patterns/ansible-gitops-framework/_index.md
+++ b/content/patterns/ansible-gitops-framework/_index.md
@@ -10,7 +10,8 @@ industries:
 aliases: /agof/
 pattern_logo: ansible-edge.png
 links:
-  install: https://github.com/validatedpatterns/agof/
+  github: https://github.com/validatedpatterns/agof/
+  install: https://github.com/validatedpatterns/agof/?tab=readme-ov-file#11-installation
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/agof/issues
 ---

--- a/content/patterns/cockroachdb/_index.md
+++ b/content/patterns/cockroachdb/_index.md
@@ -6,6 +6,11 @@ Summary: A multicloud pattern using cockroachdb and submariner, deployed via RHA
 rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
+links:
+  github: https://github.com/validatedpatterns/cockroachdb-pattern/
+  install: https://github.com/validatedpatterns/cockroachdb-pattern?tab=readme-ov-file#how-to-deploy
+  help: https://groups.google.com/g/validatedpatterns
+  bugs: https://github.com/validatedpatterns/cockroachdb-pattern/issues
 ---
 
 # Cockroach

--- a/content/patterns/coco-pattern/_index.adoc
+++ b/content/patterns/coco-pattern/_index.adoc
@@ -12,16 +12,18 @@ industries:
 aliases: /coco-pattern/
 pattern_logo: coco-logo.png
 links:
+  github: https://github.com/validatedpatterns/coco-pattern
   install: coco-pattern-getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/coco-pattern/issues
 ---
+
 :toc:
 :imagesdir: /images
 :_content-type: ASSEMBLY
 include::modules/comm-attributes.adoc[]
 
-= About coco-pattern
+= About the Confidential Containers pattern
 
 Confidential computing is a technology for securing data in use. It uses a https://en.wikipedia.org/wiki/Trusted_execution_environment[Trusted Execution Environment] provided within the hardware of the processor to prevent access from others who have access to the system.
 https://confidentialcontainers.org/[Confidential containers] is a project to standardize the consumption of confidential computing by making the security boundary for confidential computing to be a Kubernetes pod. https://katacontainers.io/[Kata containers] is used to establish the boundary via a shim VM.

--- a/content/patterns/connected-vehicle-architecture/_index.md
+++ b/content/patterns/connected-vehicle-architecture/_index.md
@@ -6,6 +6,11 @@ Summary: A distributed cloud-native application that implements key aspects of a
 rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Ansible Automation Platform
+links:
+  github: https://github.com/validatedpatterns/connected-vehicle-architecture
+  install: https://github.com/validatedpatterns/connected-vehicle-architecture?tab=readme-ov-file#bobby-car
+  help: https://groups.google.com/g/validatedpatterns
+  bugs: https://github.com/validatedpatterns/connected-vehicle-architecture/issues
 ---
 
 # Connected Vehicle Architecture

--- a/content/patterns/devsecops/_index.md
+++ b/content/patterns/devsecops/_index.md
@@ -15,6 +15,7 @@ aliases: /devsecops/
 # uncomment once this exists
 # pattern_logo: devsecops.png
 links:
+  github: https://github.com/validatedpatterns/multicluster-devsecops
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/multicluster-devsecops/issues

--- a/content/patterns/emerging-disease-detection/_index.adoc
+++ b/content/patterns/emerging-disease-detection/_index.adoc
@@ -13,6 +13,7 @@ industries:
 aliases: /emerging-disease-detection/
 // pattern_logo: emerging-disease-detection.png
 links:
+  github: https://github.com/validatedpatterns/emerging-disease-detection
   install: edd-getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/federated-edge-observability/_index.adoc
+++ b/content/patterns/federated-edge-observability/_index.adoc
@@ -1,6 +1,7 @@
 ---
 title: Federated Edge Observability
 date: 2025-02-01
+validated: false
 tier: sandbox
 summary: This pattern uses OpenShift Virtualization to simulate an edge environment for VMs which then report metrics via OpenTelemetry.
 rh_products:
@@ -12,6 +13,7 @@ rh_products:
 industries:
 aliases: /federated-edge-observability
 links:
+  github: https://github.com/validatedpatterns-sandbox/federated-edge-observability
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/federated-edge-observability/issues

--- a/content/patterns/gaudi-rag-chat-qna/_index.adoc
+++ b/content/patterns/gaudi-rag-chat-qna/_index.adoc
@@ -16,9 +16,10 @@ industries:
 aliases: /gaudi-rag-chat-qna/
 #pattern_logo: gaudi-rag-chat-qna.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/qna-chat-gaudi
   install: gaudi-rag-chat-qna-getting-started
   help: https://groups.google.com/g/validatedpatterns
-  bugs: https://github.com/validatedpatterns-sandbox/
+  bugs: https://github.com/validatedpatterns-sandbox/qna-chat-gaudi/issues
 ---
 :toc:
 :imagesdir: /images

--- a/content/patterns/hypershift/_index.adoc
+++ b/content/patterns/hypershift/_index.adoc
@@ -13,7 +13,8 @@ industries:
 aliases: /hypershift/
 pattern_logo: medical-diagnosis.png
 links:
-
+  github: https://github.com/validatedpatterns-sandbox/hypershift
+  install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/hypershift/issues
 ci: hypershift

--- a/content/patterns/industrial-edge/_index.md
+++ b/content/patterns/industrial-edge/_index.md
@@ -15,6 +15,7 @@ industries:
 aliases: /industrial-edge/
 pattern_logo: industrial-edge.png
 links:
+  github: https://github.com/validatedpatterns/industrial-edge
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/26-industrial-edge
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/kong-gateway/_index.md
+++ b/content/patterns/kong-gateway/_index.md
@@ -5,10 +5,15 @@ tier: sandbox
 Summary: A pattern for Kong Gateway Control Plane and Data Plane demo.
 rh_products:
 - Red Hat OpenShift Container Platform
+links:
+  github: https://github.com/validatedpatterns/kong-gateway
+  install: https://github.com/validatedpatterns/kong-gateway?tab=readme-ov-file#start-here
+  help: https://groups.google.com/g/validatedpatterns
+  bugs: https://github.com/validatedpatterns-sandbox/kong-gateway/issues
 ---
 
-# Kong
+# About the Kong pattern
 
-A pattern for Kong Gateway Control Plane and Data Plane demo
+A pattern for Kong Gateway Control Plane and Data Plane demo.
 
 [Repo](https://github.com/validatedpatterns/kong-gateway)

--- a/content/patterns/medical-diagnosis-amx/_index.adoc
+++ b/content/patterns/medical-diagnosis-amx/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel AMX accelerated Medical Diagnosis
 date: 2023-10-10
 validated: false
+tier: sandbox
 summary: This pattern is based on a demo implementation of an automated data pipeline for chest X-ray analysis previously developed by Red Hat. The pattern is modified to utilize Intel AMX feature.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -15,6 +16,7 @@ aliases: /medical-diagnosis-amx/
 variant_of: medical-diagnosis
 pattern_logo: medical-diagnosis.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/amx-accelerated-medical-diagnosis
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/medical-diagnosis/_index.adoc
+++ b/content/patterns/medical-diagnosis/_index.adoc
@@ -12,6 +12,7 @@ industries:
 aliases: /medical-diagnosis/
 pattern_logo: medical-diagnosis.png
 links:
+  github: https://github.com/validatedpatterns/medical-diagnosis
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/mlops-fraud-detection/_index.adoc
+++ b/content/patterns/mlops-fraud-detection/_index.adoc
@@ -12,6 +12,7 @@ industries:
 aliases: /mlops-fraud-detection/
 pattern_logo: mlops-fraud-detection.png
 links:
+  github: https://github.com/validatedpatterns/mlops-fraud-detection
   install: mfd-getting-started
   arch: https://www.redhat.com/architect/portfolio/architecturedetail?ppid=6
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/multicloud-gitops-Portworx/_index.md
+++ b/content/patterns/multicloud-gitops-Portworx/_index.md
@@ -14,6 +14,7 @@ aliases: /multicloud-gitops-Portworx/
 variant_of: multicloud-gitops
 pattern_logo: multicloud-gitops-Portworx.png
 links:
+  github: https://github.com/portworx/rh-multicloud-gitops-pxe
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/portworx/rh-multicloud-gitops-pxe/issues

--- a/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel AMX accelerated Multicloud GitOps with Openshift AI
 date: 2024-02-27
 validated: false
+tier: sandbox
 summary: This is extension of Multicloud GitOps pattern with Red Hat Openshift AI component to show the value of using Intel AMX.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -17,9 +18,10 @@ variant_of: multicloud-gitops
 # pattern_logo: multicloud-gitops.png
 pattern_logo: amx-intel-ai.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/amx-accelerated-rhoai-multicloud-gitops
   install: mcg-amx-rhoai-getting-started
   help: https://groups.google.com/g/validatedpatterns
-  bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops/issues
+  bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-rhoai-multicloud-gitops/issues
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops-amx/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel AMX accelerated Multicloud GitOps
 date: 2023-10-05
 validated: false
+tier: sandbox
 summary: This is extension of Multicloud GitOps pattern with additional application to show the value of using Intel AMX.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -16,6 +17,7 @@ variant_of: multicloud-gitops
 # pattern_logo: multicloud-gitops.png
 pattern_logo: amx-intel-ai.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops
   install: mcg-amx-getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops/issues

--- a/content/patterns/multicloud-gitops-qat/_index.adoc
+++ b/content/patterns/multicloud-gitops-qat/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel QAT accelerated Multicloud GitOps
 date: 2023-10-05
 validated: false
+tier: sandbox
 summary: This is extension of Multicloud GitOps pattern with additional application to show the value of using Intel QAT.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -16,6 +17,7 @@ variant_of: multicloud-gitops
 # pattern_logo: multicloud-gitops.png
 pattern_logo: intel-qat.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/qat-accelerated-istio
   install: mcg-qat-getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/qat-accelerated-istio/issues

--- a/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel SGX protected application in Multicloud GitOps
 date: 2024-02-20
 validated: false
+tier: sandbox
 summary: This is an extension of Multicloud GitOps pattern with additional application using Intel SGX.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -16,6 +17,7 @@ variant_of: multicloud-gitops
 # pattern_logo: multicloud-gitops.png
 pattern_logo: sgx-intel-ai.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world
   install: mcg-sgx-hello-world-getting-started
   help: https://groups.google.com/g/validatedpatterns
 #  bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world//issues

--- a/content/patterns/multicloud-gitops-sgx/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx/_index.adoc
@@ -2,6 +2,7 @@
 title: Intel SGX protected Vault for Multicloud GitOps
 date: 2024-02-09
 validated: false
+tier: sandbox
 summary: This is an extension of the Multicloud GitOps pattern with an additional application to show the value of using Intel SGX.
 rh_products:
 - Red Hat OpenShift Container Platform
@@ -16,6 +17,7 @@ variant_of: multicloud-gitops
 # pattern_logo: multicloud-gitops.png
 pattern_logo: sgx-intel-ai.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-vault
   install: mcg-sgx-getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-vault/issues

--- a/content/patterns/multicloud-gitops/_index.adoc
+++ b/content/patterns/multicloud-gitops/_index.adoc
@@ -11,6 +11,7 @@ industries:
 aliases: /multicloud-gitops/
 pattern_logo: multicloud-gitops.png
 links:
+  github: https://github.com/validatedpatterns/multicloud-gitops
   install: mcg-getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/8-hybrid-multicloud-management-with-gitops
   help: https://groups.google.com/g/validatedpatterns

--- a/content/patterns/openshift-ai/_index.adoc
+++ b/content/patterns/openshift-ai/_index.adoc
@@ -11,6 +11,7 @@ industries:
 - General
 aliases: /rhoai/
 links:
+  github: https://github.com/validatedpatterns-sandbox/openshift-ai
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/openshift-ai/issues

--- a/content/patterns/rag-llm-gitops/_index.md
+++ b/content/patterns/rag-llm-gitops/_index.md
@@ -12,6 +12,7 @@ aliases: /ai/
 # uncomment once this exists
 # pattern_logo: retail.png
 links:
+  github: https://github.com/validatedpatterns/rag-llm-gitops
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/rag-llm-gitops/issues

--- a/content/patterns/regional-dr/_index.md
+++ b/content/patterns/regional-dr/_index.md
@@ -8,14 +8,15 @@ rh_products:
 industries:
 pattern_logo: regional-dr.png
 links:
-  install: https://github.com/validatedpatterns/regional-resiliency-pattern
+  github: https://github.com/validatedpatterns/regional-resiliency-pattern
+  install: /regional-dr/#installation
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/regional-resiliency-pattern/issues
 ---
 
-# OpenShift Regional DR
+# OpenShift Regional Disaster Recovery
 
-## Context
+## About OpenShift Regional Disaster Recovery
 
 As more and more institution and mission critical organizations are moving 
 in the cloud, the possible impact of having a provider failure, might this be

--- a/content/patterns/retail/_index.adoc
+++ b/content/patterns/retail/_index.adoc
@@ -13,6 +13,7 @@ aliases: /retail/
 # uncomment once this exists
 # pattern_logo: retail.png
 links:
+  github: https://github.com/validatedpatterns/retail
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/retail/issues

--- a/content/patterns/travelops/_index.adoc
+++ b/content/patterns/travelops/_index.adoc
@@ -13,6 +13,7 @@ industries:
 - General
 aliases: /travelops/
 links:
+  github: https://github.com/validatedpatterns-sandbox/travelops
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/travelops/issues

--- a/content/patterns/virtualization-starter-kit/_index.md
+++ b/content/patterns/virtualization-starter-kit/_index.md
@@ -13,6 +13,7 @@ industries:
 aliases: /virtualization-starter-kit/
 pattern_logo: ansible-edge.png
 links:
+  github: https://github.com/validatedpatterns-sandbox/virtualization-starter-kit
   install: getting-started
   help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/virtualization-starter-kit

--- a/layouts/partials/links.html
+++ b/layouts/partials/links.html
@@ -1,4 +1,12 @@
 <ul class="pf-c-list pf-m-inline links-menu pf-m-align-self-center">
+{{ if (isset .Params.links "github") }}
+<li class="pf-c-list__item">
+  <span class="pf-c-list__item-icon">
+    <i class="fa-solid fa-code-fork"></i>
+  </span>
+  <a href="{{ .Params.links.github }}" class="">Source Code</a>
+</li>
+{{ end }}
 {{ if (isset .Params.links "install") }}
 <li class="pf-c-list__item">
   <span class="pf-c-icon pf-m-inline">


### PR DESCRIPTION
Add GitHub repo links in pattern headers, add partials to support this new header, and fix tiers and other linking issues
(Not very happy using the term "repo" in place to repository but in saving some space so that it's not too _crowded_.)

Issue: https://issues.redhat.com/browse/TELCODOCS-2337