### PR TITLE
Introduce a feedback form; add other connectivity options

### DIFF
--- a/archetypes/pattern/_index.adoc
+++ b/archetypes/pattern/_index.adoc
@@ -17,8 +17,9 @@ partners:
 links:
   install:
   arch:
-  help: https://groups.google.com/g/validatedpatterns
   bugs:
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
+  
 # Set tier to one of sandbox, tested, or maintained. If empty, the default
 # is sandbox
 # tier: sandbox

--- a/content/patterns/amd-rag-chat-qna/_index.adoc
+++ b/content/patterns/amd-rag-chat-qna/_index.adoc
@@ -19,8 +19,8 @@ aliases: /amd-rag-chat-qna/
 links:
   github: https://github.com/validatedpatterns-sandbox/qna-chat-amd/
   install: amd-rag-chat-qna-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/qna-chat-amd/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 :toc:
 :imagesdir: /images

--- a/content/patterns/ansible-edge-gitops-kasten/_index.md
+++ b/content/patterns/ansible-edge-gitops-kasten/_index.md
@@ -18,8 +18,8 @@ pattern_logo: veeam-kasten.png
 links:
   github: https://github.com/validatedpatterns/ansible-edge-gitops
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/ansible-edge-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 # ci: aegitops
 ---
 

--- a/content/patterns/ansible-edge-gitops/_index.adoc
+++ b/content/patterns/ansible-edge-gitops/_index.adoc
@@ -16,8 +16,8 @@ pattern_logo: ansible-edge.png
 links:
   github: https://github.com/validatedpatterns/ansible-edge-gitops/
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/ansible-edge-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: aegitops
 ---
 

--- a/content/patterns/ansible-gitops-framework/_index.md
+++ b/content/patterns/ansible-gitops-framework/_index.md
@@ -12,8 +12,8 @@ pattern_logo: ansible-edge.png
 links:
   github: https://github.com/validatedpatterns/agof/
   install: https://github.com/validatedpatterns/agof/?tab=readme-ov-file#11-installation
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/agof/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 # Ansible GitOps Framework

--- a/content/patterns/cockroachdb/_index.md
+++ b/content/patterns/cockroachdb/_index.md
@@ -9,8 +9,8 @@ rh_products:
 links:
   github: https://github.com/validatedpatterns/cockroachdb-pattern/
   install: https://github.com/validatedpatterns/cockroachdb-pattern?tab=readme-ov-file#how-to-deploy
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/cockroachdb-pattern/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 # Cockroach

--- a/content/patterns/coco-pattern/_index.adoc
+++ b/content/patterns/coco-pattern/_index.adoc
@@ -14,8 +14,8 @@ pattern_logo: coco-logo.png
 links:
   github: https://github.com/validatedpatterns/coco-pattern
   install: coco-pattern-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/coco-pattern/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 :toc:

--- a/content/patterns/connected-vehicle-architecture/_index.md
+++ b/content/patterns/connected-vehicle-architecture/_index.md
@@ -9,8 +9,8 @@ rh_products:
 links:
   github: https://github.com/validatedpatterns/connected-vehicle-architecture
   install: https://github.com/validatedpatterns/connected-vehicle-architecture?tab=readme-ov-file#bobby-car
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/connected-vehicle-architecture/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 # Connected Vehicle Architecture

--- a/content/patterns/devsecops/_index.md
+++ b/content/patterns/devsecops/_index.md
@@ -17,8 +17,8 @@ aliases: /devsecops/
 links:
   github: https://github.com/validatedpatterns/multicluster-devsecops
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/multicluster-devsecops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: devsecops
 ---
 

--- a/content/patterns/emerging-disease-detection/_index.adoc
+++ b/content/patterns/emerging-disease-detection/_index.adoc
@@ -16,8 +16,8 @@ links:
   github: https://github.com/validatedpatterns/emerging-disease-detection
   install: edd-getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/emerging-disease-detection/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: emergingdd
 contributor:
   name: Arunkumar Nattamai Hariharan

--- a/content/patterns/federated-edge-observability/_index.adoc
+++ b/content/patterns/federated-edge-observability/_index.adoc
@@ -15,8 +15,8 @@ aliases: /federated-edge-observability
 links:
   github: https://github.com/validatedpatterns-sandbox/federated-edge-observability
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/federated-edge-observability/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: federatedobservability
 ---
 

--- a/content/patterns/gaudi-rag-chat-qna/_index.adoc
+++ b/content/patterns/gaudi-rag-chat-qna/_index.adoc
@@ -18,8 +18,8 @@ aliases: /gaudi-rag-chat-qna/
 links:
   github: https://github.com/validatedpatterns-sandbox/qna-chat-gaudi
   install: gaudi-rag-chat-qna-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/qna-chat-gaudi/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 :toc:
 :imagesdir: /images

--- a/content/patterns/hypershift/_index.adoc
+++ b/content/patterns/hypershift/_index.adoc
@@ -15,8 +15,8 @@ pattern_logo: medical-diagnosis.png
 links:
   github: https://github.com/validatedpatterns-sandbox/hypershift
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/hypershift/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: hypershift
 ---
 

--- a/content/patterns/industrial-edge/_index.md
+++ b/content/patterns/industrial-edge/_index.md
@@ -18,8 +18,8 @@ links:
   github: https://github.com/validatedpatterns/industrial-edge
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/26-industrial-edge
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/industrial-edge/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: industrialedge
 ---
 

--- a/content/patterns/kong-gateway/_index.md
+++ b/content/patterns/kong-gateway/_index.md
@@ -8,8 +8,8 @@ rh_products:
 links:
   github: https://github.com/validatedpatterns/kong-gateway
   install: https://github.com/validatedpatterns/kong-gateway?tab=readme-ov-file#start-here
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/kong-gateway/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 # About the Kong pattern

--- a/content/patterns/medical-diagnosis-amx/_index.adoc
+++ b/content/patterns/medical-diagnosis-amx/_index.adoc
@@ -19,8 +19,8 @@ links:
   github: https://github.com/validatedpatterns-sandbox/amx-accelerated-medical-diagnosis
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-medical-diagnosis/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/medical-diagnosis/_index.adoc
+++ b/content/patterns/medical-diagnosis/_index.adoc
@@ -15,8 +15,8 @@ links:
   github: https://github.com/validatedpatterns/medical-diagnosis
   install: getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/6-enabling-medical-imaging-diagnostics-with-edge
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/medical-diagnosis/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: medicaldiag
 ---
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/mlops-fraud-detection/_index.adoc
+++ b/content/patterns/mlops-fraud-detection/_index.adoc
@@ -15,8 +15,8 @@ links:
   github: https://github.com/validatedpatterns/mlops-fraud-detection
   install: mfd-getting-started
   arch: https://www.redhat.com/architect/portfolio/architecturedetail?ppid=6
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/mlops-fraud-detection/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: mfd
 contributor:
   name: Arslan Khan

--- a/content/patterns/multicloud-gitops-Portworx/_index.md
+++ b/content/patterns/multicloud-gitops-Portworx/_index.md
@@ -16,8 +16,8 @@ pattern_logo: multicloud-gitops-Portworx.png
 links:
   github: https://github.com/portworx/rh-multicloud-gitops-pxe
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/portworx/rh-multicloud-gitops-pxe/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 # ci: mcgitopspxe
 ---
 

--- a/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
@@ -20,8 +20,8 @@ pattern_logo: amx-intel-ai.png
 links:
   github: https://github.com/validatedpatterns-sandbox/amx-accelerated-rhoai-multicloud-gitops
   install: mcg-amx-rhoai-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-rhoai-multicloud-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops-amx/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx/_index.adoc
@@ -19,8 +19,8 @@ pattern_logo: amx-intel-ai.png
 links:
   github: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops
   install: mcg-amx-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/amx-accelerated-multicloud-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops-qat/_index.adoc
+++ b/content/patterns/multicloud-gitops-qat/_index.adoc
@@ -19,8 +19,8 @@ pattern_logo: intel-qat.png
 links:
   github: https://github.com/validatedpatterns-sandbox/qat-accelerated-istio
   install: mcg-qat-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/qat-accelerated-istio/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
@@ -19,8 +19,8 @@ pattern_logo: sgx-intel-ai.png
 links:
   github: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world
   install: mcg-sgx-hello-world-getting-started
-  help: https://groups.google.com/g/validatedpatterns
-#  bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world//issues
+  bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-hello-world//issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops-sgx/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx/_index.adoc
@@ -19,8 +19,8 @@ pattern_logo: sgx-intel-ai.png
 links:
   github: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-vault
   install: mcg-sgx-getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/sgx-multicloud-gitops-vault/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 include::modules/comm-attributes.adoc[]

--- a/content/patterns/multicloud-gitops/_index.adoc
+++ b/content/patterns/multicloud-gitops/_index.adoc
@@ -14,8 +14,8 @@ links:
   github: https://github.com/validatedpatterns/multicloud-gitops
   install: mcg-getting-started
   arch: https://www.redhat.com/architect/portfolio/detail/8-hybrid-multicloud-management-with-gitops
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/multicloud-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: mcgitops
 ---
 :toc:

--- a/content/patterns/openshift-ai/_index.adoc
+++ b/content/patterns/openshift-ai/_index.adoc
@@ -13,8 +13,8 @@ aliases: /rhoai/
 links:
   github: https://github.com/validatedpatterns-sandbox/openshift-ai
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/openshift-ai/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: openshiftai
 ---
 :toc:

--- a/content/patterns/rag-llm-gitops/_index.md
+++ b/content/patterns/rag-llm-gitops/_index.md
@@ -14,9 +14,8 @@ aliases: /ai/
 links:
   github: https://github.com/validatedpatterns/rag-llm-gitops
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/rag-llm-gitops/issues
-# uncomment once this exists
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: ragllm
 ---
 

--- a/content/patterns/regional-dr/_index.md
+++ b/content/patterns/regional-dr/_index.md
@@ -10,8 +10,8 @@ pattern_logo: regional-dr.png
 links:
   github: https://github.com/validatedpatterns/regional-resiliency-pattern
   install: /regional-dr/#installation
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/regional-resiliency-pattern/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 
 # OpenShift Regional Disaster Recovery

--- a/content/patterns/retail/_index.adoc
+++ b/content/patterns/retail/_index.adoc
@@ -15,9 +15,8 @@ aliases: /retail/
 links:
   github: https://github.com/validatedpatterns/retail
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns/retail/issues
-# uncomment once this exists
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: retail
 ---
 

--- a/content/patterns/travelops/_index.adoc
+++ b/content/patterns/travelops/_index.adoc
@@ -15,8 +15,8 @@ aliases: /travelops/
 links:
   github: https://github.com/validatedpatterns-sandbox/travelops
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
   bugs: https://github.com/validatedpatterns-sandbox/travelops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ci: travelops
 ---
 :toc:

--- a/content/patterns/virtualization-starter-kit/_index.md
+++ b/content/patterns/virtualization-starter-kit/_index.md
@@ -15,7 +15,7 @@ pattern_logo: ansible-edge.png
 links:
   github: https://github.com/validatedpatterns-sandbox/virtualization-starter-kit
   install: getting-started
-  help: https://groups.google.com/g/validatedpatterns
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
   bugs: https://github.com/validatedpatterns-sandbox/virtualization-starter-kit
 ci: vsk
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,4 +10,12 @@
         </div>
         <script src="{{ "js/codeblock.js"  | relURL }}"></script>
     </body>
+    <!-- Uncomment when you have sorted out the feedback partials option
+        <body>
+        {{ if .Params.links.feedback }}
+        {{ partial "feedback-form.html" . }}
+        {{ else }}
+        <p>{{ .Params.links.feedback }}</p>
+        {{ end }}
+    </body>-->
 </html>

--- a/layouts/feedback.html
+++ b/layouts/feedback.html
@@ -1,0 +1,6 @@
+<iframe src="https://docs.google.com/forms/d/e/{{ .Get "id" }}/viewform?embedded=true"
+        width="{{ .Get "width" | default "640" }}"
+        height="{{ .Get "height" | default "800" }}"
+        frameborder="0" marginheight="0" marginwidth="0">
+  Loading…
+</iframe>

--- a/layouts/partials/feedback-form.html
+++ b/layouts/partials/feedback-form.html
@@ -1,0 +1,3 @@
+<div class="feedback-form">
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform?embedded=true" width="640" height="1540" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -36,16 +36,17 @@
                     <p class="pf-c-title footer-menu-title">STAY IN TOUCH</p>
                     <nav aria-label="Stay in touch">
                         <ul class="pf-c-list pf-m-plain">
-                       <!-- Slack is not ready yet, we don't have an external channel
                             <li>
                                 <i class="prefooter-icon fa-brands fa-slack"></i>
-                                <a href="/" class="footer-link" target="top" aria-label="Join the Validated Patterns Slack">Slack</a>
+                                <a href="https://openshiftcommons.slack.com/archives/C059ABEU2ET" class="footer-link" target="top" aria-label="Join the Validated Patterns Slack">Slack</a>
                             </li>
-
-                        -->
                             <li>
-                                <i class="prefooter-icon fas fa-envelope"></i>
+                                <i class="prefooter-icon fa-brands fa-google"></i>
                                 <a href="https://groups.google.com/g/validatedpatterns" class="footer-link" target="top" aria-label="Join the Validated Patterns mailing list">Mailing list</a>
+                            </li>
+                            <li>
+                                <i class="prefooter-icon fas fa-calendar"></i>
+                                <a href="https://calendar.google.com/calendar/u/0?cid=b3BlbnNoaWZ0Y29tbW9uc3JoQGdtYWlsLmNvbQ" class="footer-link" target="top" aria-label="Join the Validated Patterns mailing list">Add calendar</a>
                             </li>
                         </ul>
                     </nav>

--- a/layouts/partials/links.html
+++ b/layouts/partials/links.html
@@ -25,20 +25,20 @@
   <a href="{{ .Params.links.arch }}" class="">Solution Architecture</a>
 </li>
 {{ end }}
-{{ if (isset .Params.links "help") }}
-<li class="pf-c-list__item">
-  <span class="pf-c-list__item-icon">
-    <i class="fa-solid fa-circle-question"></i>
-  </span>
-  <a href="{{ .Params.links.help }}" class="">Help & Feedback</a>
-</li>
-{{ end }}
 {{ if (isset .Params.links "bugs") }}
 <li class="pf-c-list__item">
   <span class="pf-c-list__item-icon">
     <i class="fa-solid fa-bug"></i>
   </span>
   <a href="{{ .Params.links.bugs }}" class="">Report Bugs</a>
+</li>
+{{ end }}
+{{ if (isset .Params.links "feedback") }}
+<li class="pf-c-list__item">
+  <span class="pf-c-list__item-icon">
+    <i class="fa-solid fa-comments"></i>
+  </span>
+  <a href="{{ .Params.links.feedback }}" class="">Share Feedback</a>
 </li>
 {{ end }}
 </ul>


### PR DESCRIPTION
Add a feedback form; add SIG Slack channel and calendar to the footer, and other smaller cosmetic changes.

The previous _Help & Feedback_ link only pointed to our Google group, but since we have moved that option to the footer, we can now add a proper feedback form using the new _Share Feedback_ link in the header text. For now, I have initiated one with some preliminary questions/options. We can modify this to our liking and need.

(Also add partials for feedback for dynamic improvements later)
Issue: https://issues.redhat.com/browse/TELCODOCS-2338