### PR TITLE
update partners for RAG LLM Gitops pattern

### DIFF
--- a/content/patterns/rag-llm-gitops/_index.md
+++ b/content/patterns/rag-llm-gitops/_index.md
@@ -6,6 +6,9 @@ summary: The goal of this demo is to showcase a Chatbot LLM application augmente
 rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat OpenShift GitOps
+partners:
+- EDB
+- Elastic
 industries:
 - General
 aliases: /ai/


### PR DESCRIPTION
Request from one of our partner managers to add EDB and Elastic as partners for the RAG LLM Gitops pattern. We will also need to update the RAG LLM pattern docs to reflect the current state and update with information about how to use the Elastic RAG DB backend but for this PR it's enough to just add the partners to the site