### PR TITLE
Fix Asciidoctor build warnings

### DIFF
--- a/content/learn/vp_add_ops_to_pattern.adoc
+++ b/content/learn/vp_add_ops_to_pattern.adoc
@@ -12,6 +12,8 @@ aliases: /ocp-framework/adding-operator-to-framework/
 :_content-type: PROCEDURE
 include::modules/comm-attributes.adoc[]
 
+== Adding Operators to the validated pattern framework
+
 Subscriptions are defined in the values files and they are OpenShift Operator subscriptions from the Operator Hub. Subscriptions contribute to the creation of a software bill of materials (SBOM), detailing all intended installations within the ClusterGroup. For example in `values-hub.yaml`, the subscriptions defined in the subscriptions section specify Operators that are installed in the hub cluster when you deploy the validated pattern.
 
 This procedure describes how subscriptions to Operators are added to the validated pattern framework.
@@ -19,20 +21,20 @@ This procedure describes how subscriptions to Operators are added to the validat
 .Procedure
 
 === 1. Identify required application services
-* Decide the application services necessary to support the workload.  
+* Decide the application services necessary to support the workload.
 * These services are managed through Operators, which handle their lifecycle within OpenShift.
 
 === 2. Define Operators in the values file
-* Use the validated pattern framework to specify required Operators in a values file (`values-<site>.yaml`).  
+* Use the validated pattern framework to specify required Operators in a values file (`values-<site>.yaml`).
 * This file should reflect the specific pattern and site type where the Operators will be deployed.
 
 === 3. Add subscription entries
-* Define the required Operators by adding subscription entries in the `values-<site>.yaml` file.  
+* Define the required Operators by adding subscription entries in the `values-<site>.yaml` file.
 * Each entry should specify:
-  ** The Operator name  
-  ** The namespace where it should be deployed  
-  ** The subscription channel  
-  ** The ClusterServiceVersion (CSV)  
+  ** The Operator name
+  ** The namespace where it should be deployed
+  ** The subscription channel
+  ** The ClusterServiceVersion (CSV)
 
 .Example: Deploying Advanced Cluster Management, AMQ, and AMQ Streams
 
@@ -64,4 +66,4 @@ subscriptions:
     csv: amq-broker-operator.v7.8.1-opr-3
 ----
 
-The validated pattern framework provisions the required Operators and deploys them to the specified namespaces, ensuring they are available for workload deployment.  
+The validated pattern framework provisions the required Operators and deploys them to the specified namespaces, ensuring they are available for workload deployment.

--- a/content/patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc
+++ b/content/patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc
@@ -9,7 +9,7 @@ aliases: /amd-rag-chat-qna/amd-rag-chat-qna-getting-started/
 include::modules/comm-attributes.adoc[]
 
 [id="deploying-amdqna-pattern"]
-= Deploying the {amdqna-pattern}
+== Deploying the {amdqna-pattern}
 
 === Prerequisites
 
@@ -31,7 +31,7 @@ If you prefer to use tools provided with this project for preparation of the pre
 
 [NOTE]
 ====
-If you are familiar with the steps necessary for downloading the `Llama-3.1-8B-Instruct` model and copying to a Minio/S3 bucket, you can do so and proceed to <<deploy_model, Deploy model via Red Hat OpenShift AI [[deploy_model]]>> afterward. OpenShift AI will be installed later during pattern execution.
+If you are familiar with the steps necessary for downloading the `Llama-3.1-8B-Instruct` model and copying to a Minio/S3 bucket, you can do so and proceed to <<deploy_model, Deploy model via Red Hat OpenShift AI>> afterward. OpenShift AI will be installed later during pattern execution.
 
 If you prefer to run the provided notebooks in another environment, you can do so and skip to <<clone_pattern_code,Clone code repository>> below for further instructions. OpenShift AI will be installed later during pattern execution.
 ====


### PR DESCRIPTION
Fixes Asciidoctor build warnings for `section title out of sequence` and `id assigned to section already in use`.

```
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 9: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 24: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 83: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 129: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 129: id assigned to section already in use: deploy_model
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 157: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 303: section title out of sequence: expected level 1, got level 2
WARN  patterns/amd-rag-chat-qna/amd-rag-chat-qna-getting-started.adoc: asciidoctor: WARNING: <stdin>: line 313: section title out of sequence: expected level 1, got level 2
WARN  learn/vp_add_ops_to_pattern.adoc: asciidoctor: WARNING: <stdin>: line 13: section title out of sequence: expected level 1, got level 2
WARN  learn/vp_add_ops_to_pattern.adoc: asciidoctor: WARNING: <stdin>: line 17: section title out of sequence: expected level 1, got level 2
WARN  learn/vp_add_ops_to_pattern.adoc: asciidoctor: WARNING: <stdin>: line 21: section title out of sequence: expected level 1, got level 2
```