### PR TITLE
Update documentation issue template description under 200 chars

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,6 +1,6 @@
 name: Create a documentation issue.
 description: |
-  ⛔ This template is connected to the Create a documentation issue button on the bottom of every `learn` and `patterns` page on the live site. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+  ⛔ Use this template only from the "Create a documentation issue" button on the site. It auto-fills fields for you. Do not use for other purposes. ⛔
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Fixes the following template issue:

<img width="626" height="186" alt="image" src="https://github.com/user-attachments/assets/1c51e919-bdeb-4b99-be7d-baa5864ecc4a" />
