### PR TITLE
fix: add prerequisites for accessing an OCP cluster with cluster-admin permissions

### DIFF
--- a/modules/mcg-deploying-mcg-pattern.adoc
+++ b/modules/mcg-deploying-mcg-pattern.adoc
@@ -232,6 +232,9 @@ Alternatively you can deploy the Multicloud GitOps pattern by using the command 
 [id="deploying-cluster-using-patternsh-file"]
 == Deploying the cluster by using the pattern.sh script
 
+.Prerequisites
+* Access to an {ocp} cluster by using an account with `cluster-admin` permissions.
+
 To deploy the cluster by using the `pattern.sh` script, complete the following steps:
 
 . Navigate to the root directory of the cloned repository by running the following command:


### PR DESCRIPTION
fixes #339 

In theory, we could create a custom role with scoped permissions instead of full cluster-admin but it would need almost the same access to resources, so the same risk surface.  