### PR TITLE
fix: use plain text "Red Hat" in trilio pattern taxonomy and fix spinner

### DIFF
--- a/content/patterns/trilio-continuous-recovery/_index.md
+++ b/content/patterns/trilio-continuous-recovery/_index.md
@@ -4,9 +4,9 @@ date: 2026-04-08
 tier: sandbox
 summary: A demonstration of Trilio Continuous Restore for stateful applications
 rh_products:
-  - Red&nbsp;Hat OpenShift Container Platform
-  - Red&nbsp;Hat OpenShift GitOps
-  - Red&nbsp;Hat Advanced Cluster Management
+  - Red Hat OpenShift Container Platform
+  - Red Hat OpenShift GitOps
+  - Red Hat Advanced Cluster Management
 partners:
   - Trilio
 industries:

--- a/static/js/patterns-browser-v2.js
+++ b/static/js/patterns-browser-v2.js
@@ -267,7 +267,7 @@ function checkCategoryObject(patternTerms, filterTerms, filter_type) {
 
 function renderSpinner() {
   // HTML for the loading spinner
-  return (`div class="pf-l-bullseye">
+  return (`<div class="pf-l-bullseye">
     <div class="pf-l-bullseye__item">
       <svg class="pf-c-spinner" role="progressbar" viewBox="0 0 100 100" aria-label="Loading..." >
       <circle class="pf-c-spinner__path" cx="50" cy="50" r="45" fill="none" />


### PR DESCRIPTION
The trilio pattern's `rh_products` used "Red&nbsp;Hat" (HTML entity), creating mismatched taxonomy entries that broke checkbox ID lookups in the patterns browser. Also fixed a missing "<" in `renderSpinner()` from the variant commit.