### PR TITLE
fix: ci: hide OCP 4.19 on CI status dashboard

### DIFF
--- a/static/data/sample-badges.json
+++ b/static/data/sample-badges.json
@@ -1,273 +1,12 @@
 [
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "industrialedge-aws-4.18-stable-badge.json",
-        "pattern": "industrialedge",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-16"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopshcp-aws-4.20-stable-badge.json",
-        "pattern": "mcgitopshcp",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-15"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "ragllm-aws-4.21-stable-badge.json",
-        "pattern": "ragllm",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-15"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "ragllm-azr-4.20-stable-badge.json",
-        "pattern": "ragllm",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-15"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
         "key": "aegitops-aws-4.18-stable-badge.json",
         "pattern": "aegitops",
         "platform": "aws",
         "operator": "N/A",
         "version": "4.18",
-        "date": "2026-04-14"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "aegitops-aws-4.21-stable-badge.json",
-        "pattern": "aegitops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-14"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "hypershift-aws-4.20-stable-badge.json",
-        "pattern": "hypershift",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-14"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "medicaldiag-aws-4.18-stable-badge.json",
-        "pattern": "medicaldiag",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-14"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "hypershift-aws-4.21-stable-badge.json",
-        "pattern": "hypershift",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-aws-4.21-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "medicaldiag-aws-4.21-stable-badge.json",
-        "pattern": "medicaldiag",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "medicaldiag-azr-4.20-stable-badge.json",
-        "pattern": "medicaldiag",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-intel-4.18-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-12"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-intel-4.20-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-12"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-intel-4.21-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-12"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-intel-4.18-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-intel-4.20-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-intel-4.21-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopsstandalone-aws-4.21-stable-badge.json",
-        "pattern": "mcgitopsstandalone",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-aws-4.21-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "patternsoperator-aws-4.18-stable-badge.json",
-        "pattern": "patternsoperator",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "travelops-aws-4.21-stable-badge.json",
-        "pattern": "travelops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-11"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "coco-azr-4.21-stable-badge.json",
-        "pattern": "coco",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-10"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopshcp-aws-4.21-stable-badge.json",
-        "pattern": "mcgitopshcp",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.21",
-        "date": "2026-04-10"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-aws-4.18-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-10"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "hypershift-aws-4.18-stable-badge.json",
-        "pattern": "hypershift",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-09"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "travelops-aws-4.18-stable-badge.json",
-        "pattern": "travelops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-09"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "travelops-aws-4.20-stable-badge.json",
-        "pattern": "travelops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-09"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "industrialedge-azr-4.20-stable-badge.json",
-        "pattern": "industrialedge",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-08"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "ragllm-aws-4.18-stable-badge.json",
-        "pattern": "ragllm",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-08"
+        "date": "2026-04-28"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
@@ -276,115 +15,16 @@
         "platform": "aws",
         "operator": "N/A",
         "version": "4.20",
-        "date": "2026-04-07"
+        "date": "2026-04-21"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopsstandalone-aws-4.20-stable-badge.json",
-        "pattern": "mcgitopsstandalone",
+        "key": "aegitops-aws-4.21-stable-badge.json",
+        "pattern": "aegitops",
         "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-07"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "coco-azr-4.18-stable-badge.json",
-        "pattern": "coco",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "coco-azr-4.20-stable-badge.json",
-        "pattern": "coco",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "layeredzerotrust-aws-4.20-stable-badge.json",
-        "pattern": "layeredzerotrust",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-aws-4.20-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-azr-4.18-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopshcp-aws-4.18-stable-badge.json",
-        "pattern": "mcgitopshcp",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopsstandalone-gcp-4.18-stable-badge.json",
-        "pattern": "mcgitopsstandalone",
-        "platform": "gcp",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-aws-4.20-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "patternsoperator-aws-4.20-stable-badge.json",
-        "pattern": "patternsoperator",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.20",
-        "date": "2026-04-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopsstandalone-aws-4.18-stable-badge.json",
-        "pattern": "mcgitopsstandalone",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.18",
-        "date": "2026-04-05"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-gcp-4.21-stable-badge.json",
-        "pattern": "mcgitops",
-        "platform": "gcp",
         "operator": "N/A",
         "version": "4.21",
-        "date": "2026-04-01"
+        "date": "2026-04-28"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
@@ -393,7 +33,70 @@
         "platform": "aws",
         "operator": "N/A",
         "version": "none",
-        "date": "2026-03-06"
+        "date": "2026-04-21"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "coco-azr-4.18-stable-badge.json",
+        "pattern": "coco",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "coco-azr-4.20-stable-badge.json",
+        "pattern": "coco",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "coco-azr-4.21-stable-badge.json",
+        "pattern": "coco",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "hypershift-aws-4.18-stable-badge.json",
+        "pattern": "hypershift",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "hypershift-aws-4.20-stable-badge.json",
+        "pattern": "hypershift",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "hypershift-aws-4.21-stable-badge.json",
+        "pattern": "hypershift",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "industrialedge-aws-4.18-stable-badge.json",
+        "pattern": "industrialedge",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-29"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
@@ -406,6 +109,24 @@
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
+        "key": "industrialedge-azr-4.20-stable-badge.json",
+        "pattern": "industrialedge",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-23"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "layeredzerotrust-aws-4.20-stable-badge.json",
+        "pattern": "layeredzerotrust",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-27"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
         "key": "mcgitops-aws-4.18-stable-badge.json",
         "pattern": "mcgitops",
         "platform": "aws",
@@ -415,156 +136,66 @@
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "aegitops-aws-4.19-stable-badge.json",
-        "pattern": "aegitops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-17"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-aws-4.19-stable-badge.json",
+        "key": "mcgitops-aws-4.20-stable-badge.json",
         "pattern": "mcgitops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-16"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopshcp-aws-4.19-stable-badge.json",
-        "pattern": "mcgitopshcp",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-16"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "medicaldiag-aws-4.20-stable-badge.json",
-        "pattern": "medicaldiag",
         "platform": "aws",
         "operator": "N/A",
         "version": "4.20",
-        "date": "2026-02-16"
+        "date": "2026-04-20"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "hypershift-aws-4.19-stable-badge.json",
-        "pattern": "hypershift",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "ragllm-aws-4.19-stable-badge.json",
-        "pattern": "ragllm",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-13"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "medicaldiag-azr-4.19-stable-badge.json",
-        "pattern": "medicaldiag",
-        "platform": "azr",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-09"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-intel-4.19-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-08"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-intel-4.19-stable-badge.json",
+        "key": "mcgitops-aws-4.21-stable-badge.json",
         "pattern": "mcgitops",
-        "platform": "intel",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-07"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitopsstandalone-aws-4.19-stable-badge.json",
-        "pattern": "mcgitopsstandalone",
         "platform": "aws",
         "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-06"
+        "version": "4.21",
+        "date": "2026-04-24"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "openshiftai-aws-4.19-stable-badge.json",
-        "pattern": "openshiftai",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-06"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "travelops-aws-4.19-stable-badge.json",
-        "pattern": "travelops",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-05"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "industrialedge-aws-4.19-stable-badge.json",
-        "pattern": "industrialedge",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-04"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "coco-azr-4.19-stable-badge.json",
-        "pattern": "coco",
+        "key": "mcgitops-azr-4.18-stable-badge.json",
+        "pattern": "mcgitops",
         "platform": "azr",
         "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-03"
+        "version": "4.18",
+        "date": "2026-04-27"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "patternsoperator-aws-4.19-stable-badge.json",
-        "pattern": "patternsoperator",
-        "platform": "aws",
-        "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-03"
-    },
-    {
-        "base": "https://storage.googleapis.com/vp-results",
-        "key": "mcgitops-gcp-4.19-stable-badge.json",
+        "key": "mcgitops-gcp-4.21-stable-badge.json",
         "pattern": "mcgitops",
         "platform": "gcp",
         "operator": "N/A",
-        "version": "4.19",
-        "date": "2026-02-01"
+        "version": "4.21",
+        "date": "2026-04-01"
     },
     {
         "base": "https://storage.googleapis.com/vp-results",
-        "key": "layeredzerotrust-aws-4.19-stable-badge.json",
-        "pattern": "layeredzerotrust",
-        "platform": "aws",
+        "key": "mcgitops-intel-4.18-stable-badge.json",
+        "pattern": "mcgitops",
+        "platform": "intel",
         "operator": "N/A",
-        "version": "4.19",
-        "date": "2025-12-22"
+        "version": "4.18",
+        "date": "2026-04-25"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitops-intel-4.20-stable-badge.json",
+        "pattern": "mcgitops",
+        "platform": "intel",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-25"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitops-intel-4.21-stable-badge.json",
+        "pattern": "mcgitops",
+        "platform": "intel",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-25"
     },
     {
         "base": "https://vp-ntnx-results.s3.amazonaws.com",
@@ -601,5 +232,257 @@
         "operator": "N/A",
         "version": "4.15",
         "date": "2024-04-03"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopshcp-aws-4.18-stable-badge.json",
+        "pattern": "mcgitopshcp",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopshcp-aws-4.20-stable-badge.json",
+        "pattern": "mcgitopshcp",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopshcp-aws-4.21-stable-badge.json",
+        "pattern": "mcgitopshcp",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopsstandalone-aws-4.18-stable-badge.json",
+        "pattern": "mcgitopsstandalone",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-05"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopsstandalone-aws-4.20-stable-badge.json",
+        "pattern": "mcgitopsstandalone",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopsstandalone-aws-4.21-stable-badge.json",
+        "pattern": "mcgitopsstandalone",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "mcgitopsstandalone-gcp-4.18-stable-badge.json",
+        "pattern": "mcgitopsstandalone",
+        "platform": "gcp",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "medicaldiag-aws-4.18-stable-badge.json",
+        "pattern": "medicaldiag",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-27"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "medicaldiag-aws-4.20-stable-badge.json",
+        "pattern": "medicaldiag",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-02-16"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "medicaldiag-aws-4.21-stable-badge.json",
+        "pattern": "medicaldiag",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "medicaldiag-azr-4.20-stable-badge.json",
+        "pattern": "medicaldiag",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-27"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-aws-4.18-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-aws-4.20-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-aws-4.21-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-intel-4.18-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "intel",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-26"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-intel-4.20-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "intel",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-26"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "openshiftai-intel-4.21-stable-badge.json",
+        "pattern": "openshiftai",
+        "platform": "intel",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-26"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "patternsoperator-aws-4.18-stable-badge.json",
+        "pattern": "patternsoperator",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "patternsoperator-aws-4.20-stable-badge.json",
+        "pattern": "patternsoperator",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "ragllm-aws-4.18-stable-badge.json",
+        "pattern": "ragllm",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-29"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "ragllm-aws-4.21-stable-badge.json",
+        "pattern": "ragllm",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-15"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "ragllm-azr-4.20-stable-badge.json",
+        "pattern": "ragllm",
+        "platform": "azr",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-15"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "retail-aws-4.18-stable-badge.json",
+        "pattern": "retail",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "retail-aws-4.20-stable-badge.json",
+        "pattern": "retail",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "retail-aws-4.21-stable-badge.json",
+        "pattern": "retail",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "travelops-aws-4.18-stable-badge.json",
+        "pattern": "travelops",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.18",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "travelops-aws-4.20-stable-badge.json",
+        "pattern": "travelops",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.20",
+        "date": "2026-04-17"
+    },
+    {
+        "base": "https://storage.googleapis.com/vp-results",
+        "key": "travelops-aws-4.21-stable-badge.json",
+        "pattern": "travelops",
+        "platform": "aws",
+        "operator": "N/A",
+        "version": "4.21",
+        "date": "2026-04-24"
     }
 ]

--- a/static/js/dashboard.v2.js
+++ b/static/js/dashboard.v2.js
@@ -44,6 +44,18 @@ function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+// Still present in badge buckets but no longer in the CI matrix (omit from dashboard)
+var CI_DASHBOARD_EXCLUDED_OCP_VERSIONS = ['4.19']
+
+function excludeRetiredOcpVersionsFromDashboard (badges) {
+  if (!badges || badges.length === 0) {
+    return badges || []
+  }
+  return badges.filter(function (b) {
+    return CI_DASHBOARD_EXCLUDED_OCP_VERSIONS.indexOf(b.version) === -1
+  })
+}
+
 function filterBadges (badges, field, value) {
   if (field === 'pattern') {
     return badges.filter(badge => badge.pattern === value)
@@ -1094,6 +1106,7 @@ function getBadges (xmlText, bucket_url, badge_set) {
 }
 
 function processBadges (badges, options) {
+  badges = excludeRetiredOcpVersionsFromDashboard(badges)
   if (options.get('disable_buttons') === true) {
     processBadgesLegacy(badges, options)
     return


### PR DESCRIPTION
This pull request updates the dashboard logic to exclude badges for OCP version 4.19, which is no longer present in the CI matrix but still appears in badge buckets. The main change is the introduction of a filter that omits these retired versions from the dashboard display.

Badge filtering improvements:

* Added a constant `CI_DASHBOARD_EXCLUDED_OCP_VERSIONS` and a function `excludeRetiredOcpVersionsFromDashboard` in `dashboard.v2.js` to filter out badges for OCP version 4.19 from the dashboard.
* Updated the `processBadges` function in `dashboard.v2.js` to apply the exclusion filter before further processing badges.