### PR TITLE
Added Pattern focus areas, and Third-party trademark statements

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ taxonomies:
   industry: 'industries'
   rh_product: 'rh_products'
   partners: 'partners'
+  focus_area: 'focus_areas'
   blog_tag: 'blog_tags'
 
 mediaTypes:

--- a/content/patterns/_index.md
+++ b/content/patterns/_index.md
@@ -9,4 +9,4 @@ outputs:
   - json
 ---
 
-Browse through available patterns and their respective documentation for deployment and operation. Filter patterns by type, industry, and product.
+Browse through available patterns and their respective documentation for deployment and operation. Filter patterns by tier, focus area, industry, and product.

--- a/content/patterns/amd-rag-chat-qna/_index.adoc
+++ b/content/patterns/amd-rag-chat-qna/_index.adoc
@@ -14,6 +14,10 @@ partners:
 - AMD
 industries:
 - General
+focus_areas:
+- AI
+- Data
+- Observability
 aliases: /amd-rag-chat-qna/
 #pattern_logo: amd-rag-chat-qna.png
 links:

--- a/content/patterns/ansible-edge-gitops-kasten/_index.md
+++ b/content/patterns/ansible-edge-gitops-kasten/_index.md
@@ -13,6 +13,10 @@ partners:
 - Veeam Kasten
 industries:
 - Chemical
+focus_areas:
+- Edge
+- Virtualization
+- Resilience
 aliases: /ansible-edge-gitops-kasten/
 pattern_logo: veeam-kasten.png
 links:

--- a/content/patterns/ansible-edge-gitops/_index.adoc
+++ b/content/patterns/ansible-edge-gitops/_index.adoc
@@ -11,6 +11,10 @@ rh_products:
 - Red Hat OpenShift Data Foundation
 industries:
 - Chemical
+focus_areas:
+- Edge
+- Virtualization
+- DevSecOps
 aliases: /ansible-edge-gitops/
 pattern_logo: ansible-edge.png
 links:

--- a/content/patterns/ansible-gitops-framework/_index.md
+++ b/content/patterns/ansible-gitops-framework/_index.md
@@ -7,6 +7,9 @@ rh_products:
 - Red Hat Ansible Automation Platform
 - Red Hat Enterprise Linux
 industries:
+focus_areas:
+- DevSecOps
+- Security
 aliases: /agof/
 pattern_logo: ansible-edge.png
 links:

--- a/content/patterns/azure-rag-llm-gitops/_index.adoc
+++ b/content/patterns/azure-rag-llm-gitops/_index.adoc
@@ -11,6 +11,10 @@ partners:
 - Microsoft
 industries:
 - General
+focus_areas:
+- AI
+- Data
+- DevSecOps
 aliases: /azure-rag-llm-gitops/
 #pattern_logo:
 links:

--- a/content/patterns/cockroachdb/_index.md
+++ b/content/patterns/cockroachdb/_index.md
@@ -11,6 +11,9 @@ links:
   install: https://github.com/validatedpatterns/cockroachdb-pattern?tab=readme-ov-file#how-to-deploy
   bugs: https://github.com/validatedpatterns/cockroachdb-pattern/issues
   feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
+focus_areas:
+- Data
+- Resilience
 ---
 
 # Cockroach

--- a/content/patterns/coco-pattern/_index.adoc
+++ b/content/patterns/coco-pattern/_index.adoc
@@ -10,6 +10,9 @@ rh_products:
 - Red Hat Build of Trustee
 industries:
 - General
+focus_areas:
+- Security
+- Virtualization
 aliases: /coco-pattern/
 pattern_logo: coco-logo.png
 links:

--- a/content/patterns/connected-vehicle-architecture/_index.md
+++ b/content/patterns/connected-vehicle-architecture/_index.md
@@ -11,6 +11,10 @@ links:
   install: https://github.com/validatedpatterns/connected-vehicle-architecture?tab=readme-ov-file#bobby-car
   bugs: https://github.com/validatedpatterns/connected-vehicle-architecture/issues
   feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
+focus_areas:
+- Edge
+- Data
+- Observability
 ---
 
 # Connected Vehicle Architecture

--- a/content/patterns/devsecops/_index.md
+++ b/content/patterns/devsecops/_index.md
@@ -11,6 +11,10 @@ rh_products:
 - Red Hat Advanced Cluster Security
 industries:
 - General
+focus_areas:
+- DevSecOps
+- Security
+- Observability
 aliases: /devsecops/
 # uncomment once this exists
 # pattern_logo: devsecops.png

--- a/content/patterns/emerging-disease-detection/_index.adoc
+++ b/content/patterns/emerging-disease-detection/_index.adoc
@@ -10,6 +10,10 @@ rh_products:
 - Red Hat AMQ Streams
 industries:
 - medical
+focus_areas:
+- AI
+- Data
+- Observability
 aliases: /emerging-disease-detection/
 // pattern_logo: emerging-disease-detection.png
 links:

--- a/content/patterns/federated-edge-observability/_index.adoc
+++ b/content/patterns/federated-edge-observability/_index.adoc
@@ -11,6 +11,10 @@ rh_products:
 - Red Hat Enterprise Linux
 - Red Hat OpenShift Data Foundation
 industries:
+focus_areas:
+- Edge
+- Observability
+- Virtualization
 aliases: /federated-edge-observability
 links:
   github: https://github.com/validatedpatterns-sandbox/federated-edge-observability

--- a/content/patterns/gaudi-rag-chat-qna/_index.adoc
+++ b/content/patterns/gaudi-rag-chat-qna/_index.adoc
@@ -14,6 +14,9 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- AI
+- Data
 aliases: /gaudi-rag-chat-qna/
 #pattern_logo: gaudi-rag-chat-qna.png
 links:

--- a/content/patterns/gpfs-tester/_index.adoc
+++ b/content/patterns/gpfs-tester/_index.adoc
@@ -7,6 +7,9 @@ rh_products:
 - Red Hat OpenShift Container Platform
 industries:
 - storage services
+focus_areas:
+- Data
+- Resilience
 aliases: /gpfs-tester/
 pattern_logo: mlops-fraud-detection.png
 links:

--- a/content/patterns/hypershift/_index.adoc
+++ b/content/patterns/hypershift/_index.adoc
@@ -10,6 +10,9 @@ partners:
 - AWS Controller for Kubernetes
 industries:
 - Infrastructure
+focus_areas:
+- Edge
+- Resilience
 aliases: /hypershift/
 pattern_logo: medical-diagnosis.png
 links:

--- a/content/patterns/industrial-edge/_index.md
+++ b/content/patterns/industrial-edge/_index.md
@@ -12,6 +12,10 @@ rh_products:
 industries:
 - Industrial
 - Manufacturing
+focus_areas:
+- Edge
+- Observability
+- Security
 aliases: /industrial-edge/
 pattern_logo: industrial-edge.png
 links:

--- a/content/patterns/ingress-mesh-bgp/_index.adoc
+++ b/content/patterns/ingress-mesh-bgp/_index.adoc
@@ -10,6 +10,10 @@ rh_products:
 industries:
 - General
 - Telecommunications
+focus_areas:
+- Edge
+- Observability
+- Resilience
 aliases: /ingress-mesh-bgp/
 # pattern_logo: ingress-mesh-bgp.png  # TODO: Create pattern logo
 links:

--- a/content/patterns/kong-gateway/_index.md
+++ b/content/patterns/kong-gateway/_index.md
@@ -10,6 +10,9 @@ links:
   install: https://github.com/validatedpatterns/kong-gateway?tab=readme-ov-file#start-here
   bugs: https://github.com/validatedpatterns-sandbox/kong-gateway/issues
   feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
+focus_areas:
+- Security
+- Observability
 ---
 
 # About the Kong pattern

--- a/content/patterns/layered-zero-trust/_index.adoc
+++ b/content/patterns/layered-zero-trust/_index.adoc
@@ -6,6 +6,9 @@ summary: Layered Zero Trust demonstrates how to operationalize Zero Trust securi
 rh_products:
 - Red Hat OpenShift Container Platform
 industries:
+focus_areas:
+- Security
+- DevSecOps
 aliases: /layered-zero-trust/
 links:
   github: https://github.com/validatedpatterns/layered-zero-trust/

--- a/content/patterns/medical-diagnosis-amx/_index.adoc
+++ b/content/patterns/medical-diagnosis-amx/_index.adoc
@@ -12,6 +12,9 @@ partners:
 - Intel
 industries:
 - medical
+focus_areas:
+- AI
+- Data
 aliases: /medical-diagnosis-amx/
 variant_of: medical-diagnosis
 pattern_logo: medical-diagnosis.png

--- a/content/patterns/medical-diagnosis/_index.adoc
+++ b/content/patterns/medical-diagnosis/_index.adoc
@@ -11,6 +11,9 @@ partners:
   - IBM Fusion
 industries:
 - medical
+focus_areas:
+- AI
+- Data
 aliases: /medical-diagnosis/
 pattern_logo: medical-diagnosis.png
 links:

--- a/content/patterns/mlops-fraud-detection/_index.adoc
+++ b/content/patterns/mlops-fraud-detection/_index.adoc
@@ -10,6 +10,10 @@ partners:
 - IBM Fusion
 industries:
 - financial services
+focus_areas:
+- AI
+- Data
+- Observability
 aliases: /mlops-fraud-detection/
 pattern_logo: mlops-fraud-detection.png
 links:

--- a/content/patterns/multicloud-gitops-Portworx/_index.md
+++ b/content/patterns/multicloud-gitops-Portworx/_index.md
@@ -7,9 +7,13 @@ rh_products:
 - Red Hat OpenShift Container Platform
 - Red Hat Advanced Cluster Management
 partners:
-- Portworx Enterprise
+- Portworx by Everpure
 industries:
 - General
+focus_areas:
+- DevSecOps
+- Resilience
+- Data
 aliases: /multicloud-gitops-Portworx/
 variant_of: multicloud-gitops
 pattern_logo: multicloud-gitops-Portworx.png

--- a/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx-rhoai/_index.adoc
@@ -12,6 +12,10 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- AI
+- DevSecOps
+- Data
 aliases: /multicloud-gitops-amx-rhoai/
 variant_of: multicloud-gitops
 # uncomment once this exists

--- a/content/patterns/multicloud-gitops-amx/_index.adoc
+++ b/content/patterns/multicloud-gitops-amx/_index.adoc
@@ -11,6 +11,10 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- AI
+- DevSecOps
+- Data
 aliases: /multicloud-gitops-amx/
 variant_of: multicloud-gitops
 # uncomment once this exists

--- a/content/patterns/multicloud-gitops-qat/_index.adoc
+++ b/content/patterns/multicloud-gitops-qat/_index.adoc
@@ -11,6 +11,9 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- Security
+- DevSecOps
 aliases: /multicloud-gitops-qat/
 variant_of: multicloud-gitops
 # uncomment once this exists

--- a/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx-hello-world/_index.adoc
@@ -11,6 +11,9 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- Security
+- DevSecOps
 aliases: /multicloud-gitops-sgx-hello-world/
 variant_of: multicloud-gitops
 # uncomment once this exists

--- a/content/patterns/multicloud-gitops-sgx/_index.adoc
+++ b/content/patterns/multicloud-gitops-sgx/_index.adoc
@@ -11,6 +11,9 @@ partners:
 - Intel
 industries:
 - General
+focus_areas:
+- Security
+- DevSecOps
 aliases: /multicloud-gitops-sgx/
 variant_of: multicloud-gitops
 # uncomment once this exists

--- a/content/patterns/multicloud-gitops/_index.adoc
+++ b/content/patterns/multicloud-gitops/_index.adoc
@@ -8,6 +8,10 @@ rh_products:
 - Red Hat Advanced Cluster Management
 industries:
 - General
+focus_areas:
+- DevSecOps
+- Resilience
+- Security
 aliases: /multicloud-gitops/
 pattern_logo: multicloud-gitops.png
 links:

--- a/content/patterns/netapp-dr-starter-kit/_index.adoc
+++ b/content/patterns/netapp-dr-starter-kit/_index.adoc
@@ -11,6 +11,9 @@ rh_products:
 - Red Hat OpenShift Virtualization
 industries:
 - General
+focus_areas:
+- Resilience
+- Data
 aliases: /netapp-dr-starter-kit/
 links:
   github: https://github.com/validatedpatterns-sandbox/netapp-dr-starter-kit

--- a/content/patterns/omnicloud/_index.md
+++ b/content/patterns/omnicloud/_index.md
@@ -9,6 +9,10 @@ rh_products:
   - Red Hat Quay
 industries:
   - General
+focus_areas:
+  - DevSecOps
+  - Resilience
+  - Data
 aliases: /omnicloud/
 # uncomment once this exists
 # pattern_logo: devsecops.png

--- a/content/patterns/openshift-ai/_index.adoc
+++ b/content/patterns/openshift-ai/_index.adoc
@@ -9,6 +9,9 @@ rh_products:
 - Red Hat Pipelines
 industries:
 - General
+focus_areas:
+- AI
+- Data
 aliases: /rhoai/
 links:
   github: https://github.com/validatedpatterns-sandbox/openshift-ai

--- a/content/patterns/portworx-dr/_index.adoc
+++ b/content/patterns/portworx-dr/_index.adoc
@@ -14,6 +14,9 @@ rh_products:
 partners:
 - Portworx by Everpure
 industries: []
+focus_areas:
+- Resilience
+- Data
 aliases: /portworx-dr/
 pattern_logo: ansible-edge.png
 links:

--- a/content/patterns/rag-llm-cpu/_index.md
+++ b/content/patterns/rag-llm-cpu/_index.md
@@ -12,6 +12,9 @@ partners:
   - IBM Fusion
 industries:
   - General
+focus_areas:
+  - AI
+  - Data
 aliases: /rag-llm-cpu/
 links:
   github: https://github.com/validatedpatterns-sandbox/rag-llm-cpu

--- a/content/patterns/rag-llm-gitops/_index.md
+++ b/content/patterns/rag-llm-gitops/_index.md
@@ -12,6 +12,10 @@ partners:
   - Elastic
 industries:
   - General
+focus_areas:
+  - AI
+  - Data
+  - DevSecOps
 aliases: /ai/
 # uncomment once this exists
 # pattern_logo: retail.png

--- a/content/patterns/ramendr-starter-kit/_index.adoc
+++ b/content/patterns/ramendr-starter-kit/_index.adoc
@@ -12,6 +12,10 @@ rh_products:
 - Red Hat OpenShift Data Foundation DR Hub Operator
 - Red Hat Advanced Cluster Management
 industries: []
+focus_areas:
+- Resilience
+- Data
+- Virtualization
 aliases: /ramendr-starter-kit/
 pattern_logo: ansible-edge.png
 links:

--- a/content/patterns/regional-dr/_index.md
+++ b/content/patterns/regional-dr/_index.md
@@ -6,6 +6,9 @@ summary: This variant of the Validated Patterns framework deploys a Regional Dis
 rh_products:
 - Red Hat OpenShift Container Platform
 industries:
+focus_areas:
+- Resilience
+- Data
 pattern_logo: regional-dr.png
 links:
   github: https://github.com/validatedpatterns/regional-resiliency-pattern

--- a/content/patterns/retail/_index.adoc
+++ b/content/patterns/retail/_index.adoc
@@ -9,6 +9,9 @@ rh_products:
 - Red Hat AMQ
 industries:
 - Retail
+focus_areas:
+- Data
+- Edge
 aliases: /retail/
 # uncomment once this exists
 # pattern_logo: retail.png

--- a/content/patterns/telco-hub/_index.adoc
+++ b/content/patterns/telco-hub/_index.adoc
@@ -11,6 +11,10 @@ rh_products:
 - Red Hat OpenShift Data Foundation (ODF) (Optional)
 industries:
 - Telecommunications
+focus_areas:
+- Edge
+- Resilience
+- Observability
 aliases: /telco-hub/
 # uncomment once this exists
 # pattern_logo: telco-hub.png

--- a/content/patterns/travelops/_index.adoc
+++ b/content/patterns/travelops/_index.adoc
@@ -11,6 +11,10 @@ rh_products:
 - Red Hat ElasticSearch
 industries:
 - General
+focus_areas:
+- Security
+- Observability
+- DevSecOps
 aliases: /travelops/
 links:
   github: https://github.com/validatedpatterns/travelops

--- a/content/patterns/trilio-continuous-recovery/_index.md
+++ b/content/patterns/trilio-continuous-recovery/_index.md
@@ -11,6 +11,9 @@ partners:
   - Trilio
 industries:
   - General
+focus_areas:
+  - Resilience
+  - Data
 aliases: /trilio-cr/
 links:
   github: https://github.com/trilio-demo/trilio-continuous-restore

--- a/content/patterns/virtualization-starter-kit/_index.md
+++ b/content/patterns/virtualization-starter-kit/_index.md
@@ -10,6 +10,9 @@ rh_products:
 - Red Hat OpenShift Data Foundation
 industries:
 - Any
+focus_areas:
+- Virtualization
+- Resilience
 aliases: /virtualization-starter-kit/
 pattern_logo: ansible-edge.png
 links:

--- a/layouts/partials/menu-patterns-browser.html
+++ b/layouts/partials/menu-patterns-browser.html
@@ -52,6 +52,30 @@
         </div>
       </div>
 
+      <!-- FOCUS AREAS -->
+
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="focusAreasHeading">
+          <button class="pf-c-accordion__toggle collapsed" title="Filter patterns by focus area" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFocusAreas" aria-expanded="false" aria-controls="collapseFocusAreas">
+            Focus areas <span id="FocusAreasItemsCounter"></span>
+            <span class="pf-c-accordion__toggle-icon">
+              <i class="fas fa-angle-right" aria-hidden="true"></i>
+            </span>
+            <span class="pf-c-accordion__toggle-icon">
+              <i class="fas fa-angle-down" aria-hidden="true"></i>
+            </span>
+          </button>
+        </h2>
+        <div id="collapseFocusAreas" class="pf-c-accordion__expanded-content collapse" aria-labelledby="focusAreasHeading" data-bs-parent="#patternsAccordionNav">
+          <div class="pf-c-accordion__expanded-content-body">
+            <div class="pf-c-select__menu-group">
+              <fieldset class="pf-c-select__menu-fieldset" aria-labelledby="select-checkbox-expanded-selected-group-focus-areas" id="FocusAreasItems">
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!--RED HAT PRODUCTS-->
 
       <div class="accordion-item">

--- a/layouts/partials/patterns-browser.html
+++ b/layouts/partials/patterns-browser.html
@@ -25,6 +25,8 @@
     <div class="pf-c-content" >
       {{ $patterns := where $.Pages "Section" "patterns"}}
       <div class="pf-l-stack pf-m-gutter">
+        <div class="pf-l-stack__item pattern-count-style pf-u-text-align-center" id="focus-area-chips">
+        </div>
         <div class="pf-l-stack__item pf-u-text-align-right pattern-count-style">
           <label class="pf-c-form__label" for="form-vertical-name">
             <span class="pf-c-form__label-text">Sort:</span>
@@ -36,9 +38,9 @@
             aria-label="Selector for pattern sort"
             onchange="filterSelection()"
           >
-            <option value="atoz" selected>A to Z</option>
+            <option value="atoz">A to Z</option>
             <option value="ztoa">Z to A</option>
-            <option value="newest">Newest</option>
+            <option value="newest" selected>Newest</option>
             <option value="oldest">Oldest</option>
           </select>
         </div>

--- a/layouts/partials/patterns-index.html
+++ b/layouts/partials/patterns-index.html
@@ -3,6 +3,41 @@
     {{ partial "menu-patterns.html" . }}
   </div>
 </div>
+<style>
+  .pattern-header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--pf-global--spacer--md);
+    gap: var(--pf-global--spacer--md);
+  }
+
+  .pattern-header-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding-right: var(--pf-global--spacer--md);
+  }
+
+  .pattern-header-logo {
+    flex: 0 0 auto;
+    text-align: right;
+  }
+
+  .pf-c-panel__main-body {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  @media (max-width: 768px) {
+    .pattern-header-row {
+      align-items: flex-start;
+    }
+
+    .pattern-header-logo {
+      display: none;
+    }
+  }
+</style>
 <main class="pf-c-page__main" tabindex="0">
   <section class="pf-c-page__main-section">
     {{ partial "toc-mobile.html" . }}
@@ -10,70 +45,67 @@
     <div class="pf-u-display-flex">
       {{ partial "toc.html" . }}
       <div class="pf-c-content">
-        <div class="pf-c-panel pf-m-raised">
+        <div class="pf-c-panel">
           <div class="pf-c-panel__main">
             <div class="pf-c-panel__main-body">
-              <div class="pf-l-grid pf-m-gutter">
-                <div class="pf-l-grid__item pf-m-10-col">
-                  <h1 class="pf-c-title pf-m-4xl">{{ .Title }}</h1>
-                </div>
-                <div class="pf-l-grid__item pf-m-2-col">
-                  {{ if (isset .Params "pattern_logo") }}
-                  <div class="pf-c-panel">
-                    <div class="pf-c-panel__main">
-                      <div class="pf-c-panel__main-body pf-u-text-align-right">
-                        <img src="/images/logos/{{ .Params.pattern_logo }}" class="pattern_logo" alt="Points">
-                      </div>
-                    </div>
+              <p class="pf-u-font-size-sm pf-u-color-200 pf-u-font-weight-bold pf-u-text-transform-uppercase pf-u-mb-sm">Pattern</p>
+              <div class="pattern-header-row">
+                <div class="pattern-header-title">
+                  <h1 class="pf-c-title pf-m-4xl pf-u-mt-0">{{ .Title }}</h1>
+                  {{ if or (isset .Params "authors") (isset .Params "company") }}
+                  <div class="pf-u-mt-sm pf-u-color-200">
+                    {{ if (isset .Params "authors") }}
+                      {{ partial "authors.html" . }}
+                    {{ end }}
+                    {{ if and (isset .Params "authors") (isset .Params "company") }}
+                      <span class="pf-u-mx-sm">|</span>
+                    {{ end }}
+                    {{ if (isset .Params "company") }}
+                      {{ .Params.company }}
+                    {{ end }}
                   </div>
                   {{ end }}
                 </div>
-                {{ if (isset .Params "authors") }}
-                <div class="pf-l-grid__item pf-m-3-col">
-                  Author{{if (gt .Params.authors 1)}}s{{ end }}:
-                </div>
-                <div class="pf-l-grid__item pf-m-9-col">
-                  {{ partial "authors.html" . }}
-                </div>
-                {{ end }}
-                {{ if (isset .Params "company") }}
-                <div class="pf-l-grid__item pf-m-3-col">
-                  Company:
-                </div>
-                <div class="pf-l-grid__item pf-m-9-col">
-                  {{ .Params.company }}
-                </div>
-                {{ end }}
-                <div class="pf-l-grid__item pf-m-3-col">
-                  Validation status:
-                </div>
-                <div class="pf-l-grid__item pf-m-9-col">
-                  {{ $validated := .Param "tier" }}
-                  {{ if (eq $validated "maintained" ) }}
-                    {{ partial "label-maintained.html" . }}
-                  {{ else if (eq $validated "tested" ) }}
-                    {{ partial "label-tested.html" . }}
+                <div class="pattern-header-logo">
+                  {{ if (isset .Params "pattern_logo") }}
+                    <img src="/images/logos/{{ .Params.pattern_logo }}" class="pattern_logo" alt="{{ .Title }} logo" style="max-height:56px; max-width:240px; width:auto; height:auto; object-fit:contain; object-position:right center;">
                   {{ else }}
-                    {{ partial "label-sandbox.html" . }}
+                    <img src="/images/logos/ansible-edge.png" alt="Ansible Edge logo" style="max-height:56px; max-width:240px; width:auto; height:auto; object-fit:contain; object-position:right center;">
                   {{ end }}
                 </div>
-                {{ if (isset .Params "ci") }}
-                <div class="pf-l-grid__item pf-m-3-col">
-                  CI status:
-                </div>
-                <div class="pf-l-grid__item pf-m-9-col">
-                  {{ partial "ci.html" . }}
-                </div>
-                {{ end }}
-                {{ if (isset .Params "links") }}
-                <div class="pf-l-grid__item pf-m-3-col">
-                  Links:
-                </div>
-                <div class="pf-l-grid__item pf-m-9-col">
-                  {{ partial "links.html" . }}
-                </div>
+              </div>
+
+              <div class="pf-u-mb-md">
+                <span class="pf-u-font-size-xs pf-u-color-200 pf-u-font-weight-bold pf-u-text-transform-uppercase pf-u-mr-md">Status</span>
+                {{ $validated := .Param "tier" }}
+                {{ if (eq $validated "maintained" ) }}
+                  {{ partial "label-maintained.html" . }}
+                {{ else if (eq $validated "tested" ) }}
+                  {{ partial "label-tested.html" . }}
+                {{ else }}
+                  {{ partial "label-sandbox.html" . }}
                 {{ end }}
               </div>
+
+              {{ if (isset .Params "ci") }}
+              <div class="pf-u-mb-md">
+                {{ partial "ci.html" . }}
+              </div>
+              {{ end }}
+
+              {{ if (isset .Params "links") }}
+              <div class="pf-u-pt-md pf-u-mb-sm">
+                <p class="pf-u-font-size-xs pf-u-color-200 pf-u-font-weight-bold pf-u-text-transform-uppercase pf-u-mb-sm">Resources</p>
+                {{ partial "links.html" . }}
+              </div>
+              {{ end }}
+
+              {{ if (isset .Params "partners") }}
+              <p class="pf-u-color-200 pf-u-font-size-sm pf-u-mt-md pf-u-mb-0">
+                {{ delimit .Params.partners ", " }} and related names, logos, and product names are trademarks or registered trademarks of their respective owners. This pattern is contributed as community content and is not an official product endorsement.
+              </p>
+              {{ end }}
+              <div class="pf-u-pt-md pf-u-mt-md" style="border-top: 1px solid var(--pf-global--BorderColor--100);"></div>
             </div>
           </div>
         </div>

--- a/layouts/patterns/list.json.json
+++ b/layouts/patterns/list.json.json
@@ -35,6 +35,15 @@
   {{- $industries_filter_types := slice "AND" "OR" }}
   {{- $industries_dict := dict "filter_list" $industries_list "filter_types" $industries_filter_types }}
 
+  {{/* Focus areas */}}
+  {{- $focus_areas := .Site.Taxonomies.focus_areas }}
+  {{- $focus_areas_list := slice }}
+  {{- range $index, $focus_area :=  $focus_areas.Alphabetical }}
+    {{- $focus_areas_list = $focus_areas_list | append (dict "Name" $focus_area.Name "LinkTitle" $focus_area.Page.LinkTitle) }}
+  {{- end }}
+  {{- $focus_areas_filter_types := slice "AND" "OR" }}
+  {{- $focus_areas_dict := dict "filter_list" $focus_areas_list "filter_types" $focus_areas_filter_types }}
+
   {{/* Tiers */}}
   {{- $tiers_list := slice -}}
   {{- $tiers_list = $tiers_list | append (dict "Name" "maintained" "LinkTitle" "Maintained" "color" "green") }}
@@ -43,6 +52,6 @@
   {{- $tiers_filter_types := slice "OR" }}
   {{- $tiers_dict := dict "filter_list" $tiers_list "filter_types" $tiers_filter_types }}
 
-  {{- $filter_categories := dict "rh_products" $rh_products_dict "partners" $partners_dict "industries" $industries_dict "tier" $tiers_dict -}}
+  {{- $filter_categories := dict "rh_products" $rh_products_dict "partners" $partners_dict "industries" $industries_dict "focus_areas" $focus_areas_dict "tier" $tiers_dict -}}
   {{- dict "patterns" $pattern_list "filter_categories" $filter_categories | jsonify }}
 {{- end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -604,6 +604,7 @@ main.pf-c-page__main {
 
 body .pf-c-content {
   position: relative;
+  min-width: 0; /* Allows flex item to shrink below content size, enabling overflow-wrap to work */
 }
 
 /* This fixes scrollspy problem when scrolling up manually */

--- a/static/js/patterns-browser-v2.js
+++ b/static/js/patterns-browser-v2.js
@@ -131,6 +131,8 @@ function getParams() {
   enabledParams.categories.tier = urlParams.getAll("tier");
   // Tier is always "and" since each pattern can only have one tier
   enabledParams.filters.tier = "and";
+  enabledParams.categories.focus_areas = urlParams.getAll("focus_areas");
+  enabledParams.filters.focus_areas = urlParams.get("focus_areas_filter");
   enabledParams.categories.industries = urlParams.getAll("industries");
   enabledParams.filters.industries = urlParams.get("industries_filter");
   enabledParams.categories.rh_products = urlParams.getAll("rh_products");
@@ -330,6 +332,80 @@ function renderFilter(elementId, filterType, filterData, enabledParams, enabledF
   element.innerHTML += renderFilterButtons(filterData.filter_types, filterType, enabledFilters);
 }
 
+function renderFocusAreaChips(focusAreas) {
+  // Render focus area chips as quick single-select filters.
+  const container = document.getElementById("focus-area-chips");
+  if (!container || !focusAreas || focusAreas.filter_list.length === 0) {
+    if (container) {
+      container.innerHTML = "";
+    }
+    return;
+  }
+
+  let chipsHtml = '<div class="pf-u-display-flex pf-u-flex-wrap pf-u-justify-content-center">';
+  for (item = 0; item < focusAreas.filter_list.length; item++) {
+    const focusArea = focusAreas.filter_list[item].Name;
+    chipsHtml += (`<button class="pf-c-button pf-m-secondary pf-m-small pf-u-mr-sm pf-u-mb-sm focus-area-chip" type="button" id="focus-chip:${cleanString(focusArea)}" onclick="selectFocusAreaChip('${focusArea}')">${focusAreas.filter_list[item].LinkTitle}</button>`);
+  }
+  chipsHtml += "</div>";
+  container.innerHTML = chipsHtml;
+  syncFocusAreaChipsState();
+}
+
+function syncFocusAreaChipsState() {
+  // Highlight the chip only when exactly one focus area is selected.
+  const chipElements = document.getElementsByClassName("focus-area-chip");
+  for (item = 0; item < chipElements.length; item++) {
+    chipElements[item].classList.remove("pf-m-primary");
+    chipElements[item].classList.add("pf-m-secondary");
+  }
+
+  const focusAreaItems = document.getElementById("FocusAreasItems");
+  if (!focusAreaItems) {
+    return;
+  }
+
+  const selectedFocusAreas = focusAreaItems.querySelectorAll('input[type="checkbox"]:checked');
+  if (selectedFocusAreas.length === 1) {
+    const selectedChipId = "focus-chip:" + selectedFocusAreas[0].id.split(":")[1];
+    const selectedChip = document.getElementById(selectedChipId);
+    if (selectedChip) {
+      selectedChip.classList.remove("pf-m-secondary");
+      selectedChip.classList.add("pf-m-primary");
+    }
+  }
+}
+
+function selectFocusAreaChip(focusAreaName) {
+  // Chip click replaces current focus area selection with one value.
+  const focusAreaItems = document.getElementById("FocusAreasItems");
+  if (!focusAreaItems) {
+    return;
+  }
+
+  const checkboxes = focusAreaItems.querySelectorAll('input[type="checkbox"]');
+  for (item = 0; item < checkboxes.length; item++) {
+    checkboxes[item].checked = false;
+  }
+
+  const targetCheckbox = document.getElementById("focus_areas:" + cleanString(focusAreaName));
+  if (targetCheckbox) {
+    targetCheckbox.checked = true;
+  }
+
+  // Keep single-chip selection URL behavior deterministic.
+  const focusAreaOrButton = document.getElementById("focus_areas_button:or");
+  const focusAreaAndButton = document.getElementById("focus_areas_button:and");
+  if (focusAreaAndButton) {
+    focusAreaAndButton.classList.remove("pf-m-selected");
+  }
+  if (focusAreaOrButton) {
+    focusAreaOrButton.classList.add("pf-m-selected");
+  }
+
+  filterSelection();
+}
+
 function renderLabel(tier, tier_categories) {
   // HTML to render the pattern tier label
   if (tier != undefined) {
@@ -407,9 +483,12 @@ function renderFilteredCards(patterns, filter_categories) {
 }
 
 function updateFilterCounters() {
-  const elementIds = ["TiersItems", "IndustriesItems", "RhProductsItems", "PartnersItems"]
+  const elementIds = ["TiersItems", "FocusAreasItems", "IndustriesItems", "RhProductsItems", "PartnersItems"]
   for (const elementId of elementIds) {
     const element = document.getElementById(elementId);
+    if (!element) {
+      continue;
+    }
     const elementCounter = document.getElementById(elementId + "Counter");
     var count = element.querySelectorAll('input[type="checkbox"]:checked').length;
     if (count > 0) {
@@ -418,6 +497,7 @@ function updateFilterCounters() {
       elementCounter.innerHTML = "";
     }
   }
+  syncFocusAreaChipsState();
 }
 
 function filterSelection(filter) {
@@ -498,8 +578,10 @@ const patternsData = getData();
 const enabledParams = getParams();
 patternsData.then(output => {
   renderFilter("TiersItems", "tier", output.filter_categories.tier, enabledParams.categories.tier, enabledParams.filters.tier);
+  renderFilter("FocusAreasItems", "focus_areas", output.filter_categories.focus_areas, enabledParams.categories.focus_areas, enabledParams.filters.focus_areas);
   renderFilter("IndustriesItems", "industries", output.filter_categories.industries, enabledParams.categories.industries, enabledParams.filters.industries);
   renderFilter("RhProductsItems", "rh_products", output.filter_categories.rh_products, enabledParams.categories.rh_products, enabledParams.filters.rh_products);
   renderFilter("PartnersItems", "partners", output.filter_categories.partners, enabledParams.categories.partners, enabledParams.filters.partners);
+  renderFocusAreaChips(output.filter_categories.focus_areas);
   renderFilteredCards(output.patterns, output.filter_categories)
 });


### PR DESCRIPTION
For https://redhat.atlassian.net/browse/MBP-1085

1. Added a new `focus_areas` taxonomy and integrated it into the `/patterns/` browser with sidebar filters, top quick-filter chips, URL state support, and full pattern metadata backfill.
2. Refined the pattern page header metadata block: improved title/logo layout, clearer status/resources sections, partner attribution messaging, mobile behavior updates, and visual cleanup.