### PR TITLE
fix: Update Ruby version for failing gems

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.3'
 
       - run: gem install asciidoctor rouge
 

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
This pull request updates the Ruby version used in the GitHub Actions workflows from 2.7 to 3.3. This ensures that our CI processes use a more recent and supported Ruby version.

Workflow updates:

* Updated the Ruby version to 3.3 in the `.github/workflows/gh-pages.yml` workflow.
* Updated the Ruby version to 3.3 in the `.github/workflows/htmltest.yml` workflow.