### PR TITLE
feat(patterns): add rhoso-gitops pattern docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -39,9 +39,9 @@ anattama
 anonymized
 anonymizer
 ansible
-api's
 apicast
 apicurito
+api's
 apis
 apiversion
 appdev
@@ -109,6 +109,7 @@ cacert
 cakephp
 canarypausestep
 cas
+ccvdr
 cdd
 cdh
 cdn
@@ -128,6 +129,7 @@ chown
 chroot
 cicd
 cj
+cjeanner
 ckollujlir
 claudiol
 cli
@@ -193,6 +195,7 @@ cryptographic
 csi
 csr
 csv
+csvs
 ctdim
 ctrl
 cuda
@@ -209,6 +212,7 @@ dasv
 datacenter
 dataflow
 datagrid
+dataplane
 dataset
 datasets
 datasheet
@@ -315,6 +319,7 @@ externalurl
 extraconfig
 facto
 fadc
+faipqlsci
 fc
 fcb
 fcea
@@ -340,6 +345,7 @@ fs
 fssl
 fsv
 fsync
+fu
 fvsm
 fx
 gapped
@@ -393,6 +399,7 @@ hc
 hcl
 hcp
 hdsr
+healthcheck
 helloworld
 helmoverrides
 helmrepourl
@@ -510,6 +517,8 @@ jtf
 jumpstart
 jupyter
 jws
+jyerthqlkjdugwqbg
+jyerthqlkjdugwqbg7vcg
 kafdrop
 kafkasource
 kafkatopic
@@ -708,11 +717,12 @@ opendatahub
 openid
 openjdk
 openshift
-openshift's
 openshiftpullsecret
+openshift's
 openshiftsdn
 openshiftversion
 openssl
+openstack
 openvino
 openvinotoolkit
 operatorchannel
@@ -776,6 +786,7 @@ predeploy
 prem
 preplay
 preprocess
+prereq
 prereqs
 prerequisitesrequirements
 privatekey
@@ -831,8 +842,8 @@ renderers
 replicaset
 replicasets
 repo
-repo's
 repolist
+repo's
 repos
 repourl
 reranked
@@ -852,6 +863,7 @@ rhoai
 rhocp
 rhodf
 rhods
+rhoso
 rhpam
 rhpds
 rhsm
@@ -961,6 +973,7 @@ svg
 synapseai
 synched
 syncpolicy
+syncwave
 sys
 syscall
 targetbucket
@@ -1037,8 +1050,8 @@ unsealvault
 untrusted
 updatingconfig
 updatingversion
-upstream's
 upstreaming
+upstream's
 ure
 uri
 usecsv
@@ -1056,6 +1069,7 @@ vaultkeys
 vaultpolicy
 vaultprefixes
 vaultproject
+vcg
 vcpu
 vcpus
 vdjtkgams
@@ -1065,6 +1079,7 @@ vectorized
 veeam
 vfio
 vhjpkievife
+viewform
 virtualmachine
 virtualmachines
 vm
@@ -1091,6 +1106,7 @@ wip
 wjalrxutnfemi/k7mdeng/bpxrficyexamplekey
 wnklrcd
 wtjq
+wypu
 wyr
 xeon
 xeons

--- a/content/patterns/rhoso-gitops/_index.adoc
+++ b/content/patterns/rhoso-gitops/_index.adoc
@@ -12,11 +12,10 @@ industries:
 focus_areas:
   - DevSecOps
 aliases: /rhoso-gitops/
-# TODO(repo-move): update github and bugs URLs to validatedpatterns-sandbox/rhoso-gitops
 links:
-  github: https://github.com/cjeanner/pattern-rhoso-gitops
+  github: https://github.com/validatedpatterns-sandbox/rhoso-gitops
   install: getting-started
-  bugs: https://github.com/cjeanner/pattern-rhoso-gitops/issues
+  bugs: https://github.com/validatedpatterns-sandbox/rhoso-gitops/issues
   feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
 ---
 

--- a/content/patterns/rhoso-gitops/_index.adoc
+++ b/content/patterns/rhoso-gitops/_index.adoc
@@ -1,0 +1,37 @@
+---
+title: RHOSO GitOps
+date: 2026-06-15
+tier: sandbox
+summary: Deploy Red Hat OpenStack Services on OpenShift using GitOps via the rhoso-gitops meta-chart.
+rh_products:
+  - Red Hat OpenShift Container Platform
+  - Red Hat OpenShift GitOps
+  - Red Hat OpenStack Services on OpenShift
+industries:
+  - General
+focus_areas:
+  - DevSecOps
+aliases: /rhoso-gitops/
+# TODO(repo-move): update github and bugs URLs to validatedpatterns-sandbox/rhoso-gitops
+links:
+  github: https://github.com/cjeanner/pattern-rhoso-gitops
+  install: getting-started
+  bugs: https://github.com/cjeanner/pattern-rhoso-gitops/issues
+  feedback: https://docs.google.com/forms/d/e/1FAIpQLScI76b6tD1WyPu2-d_9CCVDr3Fu5jYERthqLKJDUGwqBg7Vcg/viewform
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+
+include::modules/rhoso-gitops/rhoso-gitops-about.adoc[leveloffset=+1]
+
+include::modules/rhoso-gitops/rhoso-gitops-architecture.adoc[leveloffset=+1]
+
+[id="next-steps_rhoso-gitops-index"]
+== Next steps
+
+* link:getting-started[Deploy the pattern]
+* link:cluster-sizing[Review cluster sizing requirements]
+* link:configuration[Configure upstream pins and overrides]

--- a/content/patterns/rhoso-gitops/cluster-sizing.adoc
+++ b/content/patterns/rhoso-gitops/cluster-sizing.adoc
@@ -23,7 +23,7 @@ dataplane elements).
 Plan additional {rhel-short} capacity beyond the OpenShift worker sizing in
 `pattern-metadata.yaml`. Operator stages, sync order, and version pins are
 documented in the pattern repository
-link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
+link:https://github.com/validatedpatterns-sandbox/rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
 file.
 
 [id="next-steps_rhoso-gitops-cluster-sizing"]

--- a/content/patterns/rhoso-gitops/cluster-sizing.adoc
+++ b/content/patterns/rhoso-gitops/cluster-sizing.adoc
@@ -1,0 +1,33 @@
+---
+title: Cluster sizing
+weight: 20
+aliases: /rhoso-gitops/cluster-sizing/
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+include::modules/rhoso-gitops/metadata-rhoso-gitops.adoc[]
+
+include::modules/cluster-sizing-template.adoc[]
+
+[id="rhoso-gitops-dataplane-hosts"]
+== Data plane host requirements
+
+The hub cluster sizing tables above cover the {rh-ocp} nodes that host the
+{rh-rhoso-short} control plane. A full {rh-rhoso-short} deployment also
+requires separate {rhel-short} hosts for the data plane (compute nodes running
+dataplane elements).
+
+Plan additional {rhel-short} capacity beyond the OpenShift worker sizing in
+`pattern-metadata.yaml`. Operator stages, sync order, and version pins are
+documented in the pattern repository
+link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
+file.
+
+[id="next-steps_rhoso-gitops-cluster-sizing"]
+== Next steps
+
+* link:../getting-started/[Deploy the pattern]
+* link:../configuration/[Configure upstream pins and overrides]

--- a/content/patterns/rhoso-gitops/configuration.adoc
+++ b/content/patterns/rhoso-gitops/configuration.adoc
@@ -1,0 +1,18 @@
+---
+title: Configuration
+weight: 30
+aliases: /rhoso-gitops/configuration/
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+
+include::modules/rhoso-gitops/rhoso-gitops-configuration.adoc[leveloffset=+1]
+
+[id="next-steps_rhoso-gitops-configuration"]
+== Next steps
+
+* link:../getting-started/[Deploy the pattern]
+* link:../troubleshooting/[Troubleshooting]

--- a/content/patterns/rhoso-gitops/getting-started.adoc
+++ b/content/patterns/rhoso-gitops/getting-started.adoc
@@ -1,0 +1,19 @@
+---
+title: Getting started
+weight: 10
+aliases: /rhoso-gitops/getting-started/
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+
+include::modules/rhoso-gitops/rhoso-gitops-deploying.adoc[leveloffset=+1]
+
+[id="next-steps_rhoso-gitops-getting-started"]
+== Next steps
+
+* link:../configuration/[Configure the pattern]
+* link:../cluster-sizing/[Review cluster sizing]
+* link:../troubleshooting/[Troubleshooting]

--- a/content/patterns/rhoso-gitops/troubleshooting.adoc
+++ b/content/patterns/rhoso-gitops/troubleshooting.adoc
@@ -79,7 +79,7 @@ $ oc logs -n <namespace> <pod-name>
   later sync waves run.
 
 For community support, open an issue in the
-link:https://github.com/cjeanner/pattern-rhoso-gitops/issues[pattern repository].
+link:https://github.com/validatedpatterns-sandbox/rhoso-gitops/issues[pattern repository].
 
 [id="next-steps_rhoso-gitops-troubleshooting"]
 == Next steps

--- a/content/patterns/rhoso-gitops/troubleshooting.adoc
+++ b/content/patterns/rhoso-gitops/troubleshooting.adoc
@@ -1,0 +1,88 @@
+---
+title: Troubleshooting
+weight: 40
+aliases: /rhoso-gitops/troubleshooting/
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+include::modules/comm-attributes.adoc[]
+
+[id="troubleshooting-rhoso-gitops"]
+= Troubleshooting the {rhoso-gitops-pattern}
+
+[id="rhoso-gitops-validate-pattern"]
+== Validating the pattern
+
+Run pattern validation commands from the pattern repository root:
+
+[source,terminal]
+----
+$ ./pattern.sh make validate-prereq
+$ ./pattern.sh make validate-schema
+$ ./pattern.sh make argo-healthcheck
+----
+
+[id="rhoso-gitops-check-argocd"]
+== Checking Argo CD application status
+
+The pattern uses two Argo CD namespaces. List applications in each:
+
+[source,terminal]
+----
+$ oc get applications -n vp-gitops
+$ oc get applications -n openshift-gitops
+----
+
+Inspect a child application that is out of sync or unhealthy:
+
+[source,terminal]
+----
+$ oc describe application <application-name> -n openshift-gitops
+----
+
+Use the Argo CD UI in the `openshift-gitops` namespace to review sync waves,
+resource health, and diff details for upstream overlays.
+
+[id="rhoso-gitops-check-pods"]
+== Checking pod status
+
+To verify that workloads deployed successfully, list pods that are not Running or
+Completed:
+
+[source,terminal]
+----
+$ oc get pods -A | grep -v Running | grep -v Completed
+----
+
+Review logs for a specific pod:
+
+[source,terminal]
+----
+$ oc logs -n <namespace> <pod-name>
+----
+
+[id="rhoso-gitops-known-issues"]
+== Known issues
+
+* *`openstack-secrets` disabled* — The default pattern leaves
+  `openstack-secrets` disabled because no Git path is configured (`path: TODO`).
+  Enable it only after you configure secret wiring and a bootstrap credential
+  out of band. See link:../configuration/#rhoso-gitops-secret-zero[Secret zero
+  (bootstrap credential)].
+* *Upstream sync failures* — Confirm `targetRevision` and paths in
+  `overrides/values-rhoso-gitops.yaml` match a tag or branch that exists in
+  link:https://github.com/openstack-k8s-operators/gitops[openstack-k8s-operators/gitops].
+* *Operator install delays* — Infrastructure operators in `operator-dependencies`
+  subscribe from the cluster catalog; allow time for OLM to resolve CSVs before
+  later sync waves run.
+
+For community support, open an issue in the
+link:https://github.com/cjeanner/pattern-rhoso-gitops/issues[pattern repository].
+
+[id="next-steps_rhoso-gitops-troubleshooting"]
+== Next steps
+
+* link:../getting-started/[Getting started]
+* link:../configuration/[Configuration]

--- a/modules/comm-attributes.adoc
+++ b/modules/comm-attributes.adoc
@@ -115,6 +115,9 @@
 :kebab: image:kebab.png[title="Options menu"]
 :rh-openstack-first: Red{nbsp}Hat OpenStack Platform (RHOSP)
 :openstack-short: RHOSP
+:rh-rhoso: Red{nbsp}Hat OpenStack Services on OpenShift
+:rh-rhoso-short: RHOSO
+:rhoso-gitops-pattern: RHOSO GitOps pattern
 //Assisted Installer
 :ai-full: Assisted Installer
 :ai-version: 2.3

--- a/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
+++ b/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
@@ -1,0 +1,27 @@
+// This file has been generated automatically from the pattern-metadata.yaml file
+// Do not edit manually!
+:metadata_version: 1.0
+:name: rhoso-gitops
+:description: Deploy Red Hat OpenStack Services on OpenShift (RHOSO) using GitOps via the rhoso-gitops meta-chart and upstream Kustomize example overlays.
+:pattern_version: 0.1.0
+:display_name: RHOSO GitOps
+:repo_url: https://github.com/cjeanner/pattern-rhoso-gitops
+:docs_repo_url: https://github.com/validatedpatterns/docs
+:issues_url: https://github.com/cjeanner/pattern-rhoso-gitops/issues
+:docs_url: https://github.com/cjeanner/pattern-rhoso-gitops#readme
+:tier: sandbox
+:owners: cjeanner
+:requirements_hub_compute_platform_aws_replicas: 3
+:requirements_hub_compute_platform_aws_type: m5.4xlarge
+:requirements_hub_compute_platform_azure_replicas: 3
+:requirements_hub_compute_platform_azure_type: Standard_D16s_v3
+:requirements_hub_compute_platform_gcp_replicas: 3
+:requirements_hub_compute_platform_gcp_type: n1-standard-16
+:requirements_hub_controlPlane_platform_aws_replicas: 3
+:requirements_hub_controlPlane_platform_aws_type: m5.2xlarge
+:requirements_hub_controlPlane_platform_azure_replicas: 3
+:requirements_hub_controlPlane_platform_azure_type: Standard_D8s_v3
+:requirements_hub_controlPlane_platform_gcp_replicas: 3
+:requirements_hub_controlPlane_platform_gcp_type: n1-standard-8
+:extra_features_hypershift_support: false
+:extra_features_spoke_support: false

--- a/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
+++ b/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
@@ -5,10 +5,10 @@
 :description: Deploy Red Hat OpenStack Services on OpenShift (RHOSO) using GitOps via the rhoso-gitops meta-chart and upstream Kustomize example overlays.
 :pattern_version: 0.1.0
 :display_name: RHOSO GitOps
-:repo_url: https://github.com/cjeanner/pattern-rhoso-gitops
+:repo_url: https://github.com/validatedpatterns-sandbox/rhoso-gitops
 :docs_repo_url: https://github.com/validatedpatterns/docs
-:issues_url: https://github.com/cjeanner/pattern-rhoso-gitops/issues
-:docs_url: https://github.com/cjeanner/pattern-rhoso-gitops#readme
+:issues_url: https://github.com/validatedpatterns-sandbox/rhoso-gitops/issues
+:docs_url: https://github.com/validatedpatterns-sandbox/rhoso-gitops#readme
 :tier: sandbox
 :owners: cjeanner
 :requirements_hub_compute_platform_aws_replicas: 3

--- a/modules/rhoso-gitops/rhoso-gitops-about.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-about.adoc
@@ -70,5 +70,5 @@ consistency across spokes) do not apply to this pattern.
 
 This is a *sandbox tier* Validated Pattern. Support is provided by the community
 on a best-effort basis. For details, see the
-link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/SUPPORT.md[support policy]
+link:https://github.com/validatedpatterns-sandbox/rhoso-gitops/blob/main/SUPPORT.md[support policy]
 in the pattern repository.

--- a/modules/rhoso-gitops/rhoso-gitops-about.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-about.adoc
@@ -1,0 +1,74 @@
+:_content-type: CONCEPT
+:imagesdir: ../../images
+
+[id="about-rhoso-gitops-pattern"]
+= About the {rhoso-gitops-pattern}
+
+Deploying {rh-rhoso} spans operators, networking, and control-plane and data-plane
+resources. Teams that rely on imperative scripts or manual cluster changes face
+slow rollouts, configuration drift, and weak audit trails when the stack must be
+upgraded or reproduced.
+
+The {rhoso-gitops-pattern} addresses that by driving {rh-rhoso-short} from public
+Git through Argo CD: manifests stay declarative and version-controlled, and the
+cluster is reconciled to match what is declared in the repository.
+
+[id="rhoso-gitops-pattern-goals"]
+== Pattern goals
+
+The {rhoso-gitops-pattern} aims to:
+
+* Install the *rhoso-gitops* meta-chart through the Validated Patterns
+  clustergroup and {gitops-title} operator
+* Create child Argo CD Applications that sync {rh-rhoso-short} stages from upstream
+  link:https://github.com/openstack-k8s-operators/gitops[openstack-k8s-operators/gitops]
+  (`example/*` Kustomize overlays)
+* Target one {rh-ocp} cluster only; no managed-cluster spokes are in scope
+* Keep day-two changes reviewable in Git instead of one-off `oc` or Ansible runs
+
+[id="rhoso-gitops-red-hat-technologies"]
+== Red Hat technologies
+
+* {rh-ocp}
+* {gitops-title}
+* {rh-rhoso}
+
+[id="rhoso-gitops-cluster-scope"]
+== Cluster scope
+
+Validated Patterns distinguish between the *initial cluster* (where the pattern
+is installed) and *managed clusters* (additional {rh-ocp} clusters or hosts
+managed from that hub, for example through {rh-rhacm}).
+
+The {rhoso-gitops-pattern} is *single-cluster only*. It does not provide
+multi-cluster support, spoke provisioning, or hub-to-spoke {gitops-shortname}
+fan-out.
+
+.Cluster scope
+[cols="1,1,3",options="header"]
+|===
+| Scope | Supported | What applies
+
+| Initial cluster
+| Yes
+| Validated Patterns clustergroup (`values-standalone.yaml`), *rhoso-gitops*
+  meta-chart, and child {rh-rhoso-short} Applications in `openshift-gitops`
+
+| Managed clusters
+| None
+| Not in scope (`spoke_support: false` in `pattern-metadata.yaml`). No spoke
+  sizing, policies, {rh-rhacm} placement, or remote Argo CD instances are
+  defined or deployed
+|===
+
+Sizing guidance under `requirements.hub` in the pattern repository applies to
+the single target cluster. Managed-cluster requirements (for example eventual
+consistency across spokes) do not apply to this pattern.
+
+[id="rhoso-gitops-support"]
+== Support
+
+This is a *sandbox tier* Validated Pattern. Support is provided by the community
+on a best-effort basis. For details, see the
+link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/SUPPORT.md[support policy]
+in the pattern repository.

--- a/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
@@ -1,0 +1,98 @@
+:_content-type: CONCEPT
+:imagesdir: ../../images
+
+[id="rhoso-gitops-architecture"]
+= {rhoso-gitops-pattern} architecture
+
+[id="rhoso-gitops-gitops-delivery"]
+== GitOps delivery flow
+
+The pattern uses the Validated Patterns framework to install the *rhoso-gitops*
+Helm meta-chart. That chart creates Argo CD `Application` resources that sync
+{rh-rhoso-short} stages from the upstream
+link:https://github.com/openstack-k8s-operators/gitops[openstack-k8s-operators/gitops]
+repository (`example/*` Kustomize overlays).
+
+The delivery path is:
+
+. Validated Patterns operator reconciles the pattern clustergroup
+. Parent *rhoso-gitops* Application runs in `vp-gitops` (Validated Patterns GitOps)
+. Meta-chart renders child Applications in `openshift-gitops` ({gitops-title})
+. Child apps sync upstream `example/*` overlays in order (operators, networks,
+  control plane, dataplane)
+
+.GitOps application delivery and sync-wave ordering
+image::rhoso-gitops/rhoso-gitops-applications.svg[{rhoso-gitops-pattern} GitOps application delivery,700]
+
+The diagram shows the parent Application in `vp-gitops`, child Applications in
+`openshift-gitops`, and the upstream Kustomize overlays they sync. Sync-wave
+annotations order deployment from infrastructure operators through the data
+plane.
+
+[id="rhoso-gitops-dual-argocd"]
+== Dual Argo CD namespaces
+
+* The pattern operator deploys the parent *rhoso-gitops* Application into
+  *`vp-gitops`* (Validated Patterns GitOps).
+* Child {rh-rhoso-short} Applications are created in *`openshift-gitops`*
+  ({gitops-title} operator), per the meta-chart defaults.
+
+[id="rhoso-gitops-infrastructure-topology"]
+== Infrastructure topology
+
+An {rh-ocp} cluster hosts the {rh-rhoso-short} control plane (OpenStack operators
+and `OpenStackControlPlane` services on control-plane nodes). Separate {rhel-short}
+hosts run the {rh-rhoso-short} data plane (dataplane elements on compute nodes).
+
+The GitOps flow above describes *how* configuration is delivered. The diagram
+and list below describe *what* gets deployed:
+
+.RHOSO infrastructure topology
+image::rhoso-gitops/rhoso-gitops-infrastructure.svg[{rhoso-gitops-pattern} infrastructure topology,700]
+
+* *OpenShift cluster* — control-plane nodes run OpenStack operators and
+  `OpenStackControlPlane` services
+* *Data plane hosts* — one or more {rhel-short} compute nodes run {rh-rhoso-short}
+  dataplane elements, connected to the control plane
+
+[id="rhoso-gitops-sync-waves"]
+== Application sync order
+
+Child Applications deploy in sync-wave order when Argo CD reconciles the parent
+*rhoso-gitops* Application:
+
+[cols="2,3,1",options="header"]
+|===
+| Application | Purpose | Sync wave
+
+| `operator-dependencies`
+| Infrastructure operators (cert-manager, MetalLB, nmstate, observability)
+| `-20`
+
+| `openstack-operator`
+| OpenStack operator subscription
+| `-20`
+
+| `openstack-operator-cr`
+| Main `OpenStack` custom resource
+| `-15`
+
+| `openstack-secrets`
+| Secure-backend sync (disabled by default)
+| `-10`
+
+| `openstack-networks`
+| Network configuration
+| `0`
+
+| `openstack-controlplane`
+| `OpenStackControlPlane`
+| `10`
+
+| `openstack-dataplane`
+| Data plane
+| `20`
+|===
+
+After changing overrides, confirm child apps in the Argo CD UI or with
+`oc get applications -n openshift-gitops`.

--- a/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
@@ -1,0 +1,169 @@
+:_content-type: REFERENCE
+:imagesdir: ../../images
+
+[id="rhoso-gitops-configuration"]
+= Configuring the {rhoso-gitops-pattern}
+
+The *rhoso-gitops* meta-chart renders Argo CD `Application` resources. It does
+not deploy {rh-rhoso-short} workloads directly; Kustomize overlays in the
+upstream gitops repository remain the source of truth.
+
+[id="rhoso-gitops-values-layers"]
+== Values file layers
+
+The clustergroup application in `values-standalone.yaml` points Argo CD at
+`charts/all/rhoso-gitops` and layers pattern overrides from
+`overrides/values-rhoso-gitops.yaml` via `extraValueFiles`.
+
+.Values file layers
+[cols="1,2,3",options="header"]
+|===
+| Layer | File | Role
+
+| Pattern global
+| `values-global.yaml`
+| Pattern name, sync policy, clustergroup chart version
+
+| Cluster group
+| `values-standalone.yaml`
+| Registers the `rhoso-gitops` application and namespaces
+
+| Chart defaults
+| `charts/all/rhoso-gitops/values.yaml`
+| Default `applications` map and chart-wide keys
+
+| Pattern overrides
+| `overrides/values-rhoso-gitops.yaml`
+| Pins upstream `repoURL`, `targetRevision`, and paths
+
+| Platform overrides
+| `overrides/values-AWS.yaml`
+| Optional platform-specific overrides (placeholder)
+|===
+
+To change upstream Git content (revision, paths, enable or disable apps), edit
+`overrides/values-rhoso-gitops.yaml` and sync the pattern (or let automated
+sync reconcile, per `global.options.syncPolicy` in `values-global.yaml`).
+
+[id="rhoso-gitops-upstream-applications"]
+== Upstream applications (default `v0.1.0`)
+
+Child Argo CD Applications sync from
+link:https://github.com/openstack-k8s-operators/gitops[openstack-k8s-operators/gitops]
+at the revision pinned in `overrides/values-rhoso-gitops.yaml`.
+
+.Default upstream applications
+[cols="2,2,1",options="header"]
+|===
+| Argo CD application | Upstream path | Enabled
+
+| `operator-dependencies`
+| `example/dependencies`
+| yes
+
+| `openstack-operator`
+| `example/openstack-operator`
+| yes
+
+| `openstack-operator-cr`
+| `example/openstack-operator-cr`
+| yes
+
+| `openstack-secrets`
+| not configured (`path: TODO`)
+| no
+
+| `openstack-networks`
+| `example/openstack-networks`
+| yes
+
+| `openstack-controlplane`
+| `example/openstack-controlplane`
+| yes
+
+| `openstack-dataplane`
+| `example/openstack-dataplane`
+| yes
+|===
+
+Product, framework, upstream Git, and operator versions are listed in the pattern
+repository
+link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
+file.
+
+[id="rhoso-gitops-pin-revision"]
+== Pinning a different upstream revision
+
+In `overrides/values-rhoso-gitops.yaml`:
+
+[source,yaml]
+----
+applications:
+  openstack-operator:
+    targetRevision: "v0.2.0"
+  openstack-controlplane:
+    targetRevision: "v0.2.0"
+----
+
+Apply the same key under every application you want on that revision, or only
+the entries you need to change; unspecified keys keep chart defaults.
+
+[id="rhoso-gitops-disable-stage"]
+== Disabling a deployment stage
+
+[source,yaml]
+----
+applications:
+  openstack-dataplane:
+    enabled: false
+----
+
+[id="rhoso-gitops-repoint-overlay"]
+== Repointing an application to your Git overlay
+
+[source,yaml]
+----
+applications:
+  openstack-controlplane:
+    repoURL: "https://github.com/example/your-gitops.git"
+    path: "environments/prod/controlplane"
+    targetRevision: "main"
+----
+
+[id="rhoso-gitops-kustomize-components"]
+== Adding Kustomize components
+
+For example, to add a secrets operator component via `operator-dependencies`:
+
+[source,yaml]
+----
+applications:
+  operator-dependencies:
+    kustomize:
+      components:
+        - "https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=v0.2.0"
+----
+
+Component URLs for Vault Secrets Operator and External Secrets Operator are
+documented in the upstream
+link:https://github.com/openstack-k8s-operators/gitops/tree/main/components/secrets[components/secrets]
+readme.
+
+[id="rhoso-gitops-secret-zero"]
+== Secret zero (bootstrap credential)
+
+{rh-rhoso-short} GitOps often uses a secure store (for example Vault). The
+bootstrap credential must not live in Git. Typical steps:
+
+. Create the `openstack` namespace (or the namespace your overlay specifies).
+. Create the Kubernetes `Secret` out of band (`oc create secret generic ...`).
+. Add a Kustomize overlay in *your* Git repository for secret wiring (non-sensitive
+  manifests only).
+. Enable and configure `applications.openstack-secrets` in
+  `overrides/values-rhoso-gitops.yaml` (`enabled: true`, `repoURL`, `path`,
+  `targetRevision`, optional `kustomize` patches).
+. Install the secrets operator via `operator-dependencies` using
+  `kustomize.components` URLs from the upstream secrets components.
+
+For standalone Helm usage and advanced chart examples, see the upstream
+link:https://github.com/openstack-k8s-operators/gitops/tree/main/charts/rhoso-apps[rhoso-apps chart].

--- a/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
@@ -88,7 +88,7 @@ at the revision pinned in `overrides/values-rhoso-gitops.yaml`.
 
 Product, framework, upstream Git, and operator versions are listed in the pattern
 repository
-link:https://github.com/cjeanner/pattern-rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
+link:https://github.com/validatedpatterns-sandbox/rhoso-gitops/blob/main/VERSIONS.md[VERSIONS.md]
 file.
 
 [id="rhoso-gitops-pin-revision"]

--- a/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
@@ -22,17 +22,16 @@ Before you deploy the pattern, ensure that you have the following:
 
 .Procedure
 
-// TODO(repo-move): replace cjeanner/pattern-rhoso-gitops with validatedpatterns-sandbox/rhoso-gitops
 . Fork the
-  link:https://github.com/cjeanner/pattern-rhoso-gitops[pattern-rhoso-gitops]
+  link:https://github.com/validatedpatterns-sandbox/rhoso-gitops[rhoso-gitops]
   repository on GitHub.
 
 . Clone your fork:
 +
 [source,terminal]
 ----
-$ git clone git@github.com:<your-organization>/pattern-rhoso-gitops.git
-$ cd pattern-rhoso-gitops
+$ git clone git@github.com:<your-organization>/rhoso-gitops.git
+$ cd rhoso-gitops
 ----
 
 . Optional: if you plan to use Vault integration later, copy the secrets template:

--- a/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
@@ -1,0 +1,86 @@
+:_content-type: PROCEDURE
+:imagesdir: ../../images
+
+[id="deploying-rhoso-gitops-pattern"]
+= Deploying the {rhoso-gitops-pattern}
+
+[id="rhoso-gitops-prerequisites"]
+== Prerequisites
+
+Before you deploy the pattern, ensure that you have the following:
+
+* An {rh-ocp} 4.14 or later cluster with sufficient compute and storage for
+  {rh-rhoso-short}. For sizing guidance, see link:../cluster-sizing/[Cluster sizing].
+* Cluster administrator privileges and a working `kubeconfig`
+* link:https://podman.io/[podman] 4.3 or later for `./pattern.sh`
+* {gitops-title} available on the cluster (installed by the pattern framework or
+  pre-installed)
+* link:https://validatedpatterns.io/learn/quickstart/[Install the tooling dependencies]
+
+[id="rhoso-gitops-preparing-deployment"]
+== Preparing for deployment
+
+.Procedure
+
+// TODO(repo-move): replace cjeanner/pattern-rhoso-gitops with validatedpatterns-sandbox/rhoso-gitops
+. Fork the
+  link:https://github.com/cjeanner/pattern-rhoso-gitops[pattern-rhoso-gitops]
+  repository on GitHub.
+
+. Clone your fork:
++
+[source,terminal]
+----
+$ git clone git@github.com:<your-organization>/pattern-rhoso-gitops.git
+$ cd pattern-rhoso-gitops
+----
+
+. Optional: if you plan to use Vault integration later, copy the secrets template:
++
+[source,terminal]
+----
+$ cp values-secret.yaml.template values-secret.yaml
+----
+
+[id="rhoso-gitops-installing-pattern"]
+== Installing the pattern
+
+. Validate prerequisites without applying changes:
++
+[source,terminal]
+----
+$ ./pattern.sh make validate-prereq
+$ ./pattern.sh make show
+----
+
+. Install the pattern:
++
+[source,terminal]
+----
+$ ./pattern.sh make install
+----
+
+[id="rhoso-gitops-verifying-deployment"]
+== Verifying the deployment
+
+. Watch Argo CD applications in both GitOps namespaces:
++
+[source,terminal]
+----
+$ oc get applications -n vp-gitops
+$ oc get applications -n openshift-gitops
+----
+
+. After install, run the pattern health check:
++
+[source,terminal]
+----
+$ ./pattern.sh make argo-healthcheck
+----
+
+. Validate the pattern schema:
++
+[source,terminal]
+----
+$ ./pattern.sh make validate-schema
+----

--- a/static/images/rhoso-gitops/rhoso-gitops-applications.svg
+++ b/static/images/rhoso-gitops/rhoso-gitops-applications.svg
@@ -1,0 +1,242 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="1018px" height="1900px"
+		style="transform-origin: 0px 0px 0px;" version="1.1"
+		xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><style xmlns="http://www.w3.org/2000/svg" type="text/css"><![CDATA[
+		* {
+			text-rendering: geometricprecision !important;
+		}
+		]]><![CDATA[@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans'), local('NotoSans'), url("https://mirostatic.com/app/static/a73798e3d459e1bc.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Noto Sans Italic'), local('NotoSans-Italic'), url("https://mirostatic.com/app/static/a8edd710f88715d4.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 500;
+  src: local('Noto Sans Medium'), local('NotoSans-Medium'), url("https://mirostatic.com/app/static/006d7e33e60b9e12.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 500;
+  src: local('Noto Sans Medium Italic'), local('NotoSans-MediumItalic'), url("https://mirostatic.com/app/static/31387059566a3171.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Noto Sans SemiBold'), local('NotoSans-SemiBold'), url("https://mirostatic.com/app/static/526dd53b40975c37.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local('Noto Sans SemiBold Italic'), local('NotoSans-SemiBoldItalic'), url("https://mirostatic.com/app/static/e73d4fdd87d7e319.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Bold'), local('NotoSans-Bold'), url("https://mirostatic.com/app/static/9f11d6779c14d2bc.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 700;
+  src: local('Noto Sans Bold Italic'), local('NotoSans-BoldItalic'), url("https://mirostatic.com/app/static/888e13e017cedc15.woff2") format('woff2');
+}
+]]><![CDATA[@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/800985e1502d12bf.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/d8a7ca42a20caea5.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/3cc74c1d3919bd5c.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/f0481285dc248cf0.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/2f5e8dcf6e47bf00.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/0e625f45b71a26f1.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 800;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/645c27eb7d93eca8.woff2") format('woff2');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans Hebrew';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans Hebrew Regular'), local('Noto Sans Hebrew-Regular'), url("https://mirostatic.com/app/static/7ebe1dcf0343326c.woff2") format('woff2'), url("https://mirostatic.com/app/static/6c11f037d6968262.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans Hebrew';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Hebrew Bold'), local('Noto Sans Hebrew-Bold'), url("https://mirostatic.com/app/static/d2883e2f177d0dad.woff2") format('woff2'), url("https://mirostatic.com/app/static/8546991909eadbc9.woff") format('woff');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans JP';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans Japanese Regular'), local('Noto Sans Japanese-Regular'), url("https://mirostatic.com/app/static/9320b3c07ab79383.woff2") format('woff2'), url("https://mirostatic.com/app/static/a43be2cbcfc0b250.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans JP';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Japanese Bold'), local('Noto Sans Japanese-Bold'), url("https://mirostatic.com/app/static/7ab032c73212439f.woff2") format('woff2'), url("https://mirostatic.com/app/static/29f177f4466bd7a1.woff") format('woff');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 400;
+  src: local(''), url("https://mirostatic.com/app/static/7a5b625774730d22.woff2") format('woff2'), url("https://mirostatic.com/app/static/2d84dc606f1fb88e.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 700;
+  src: local(''), url("https://mirostatic.com/app/static/fa5a3d9073cdd58f.woff2") format('woff2'), url("https://mirostatic.com/app/static/7ded243557c83342.woff") format('woff');
+}
+]]></style><path id="LineHeadArrow2" d="M-12.727272727272727,-7.545454545454545 L0,0 L-12.727272727272727,7.545454545454545 Z"></path></defs><rect id="svg-board-background-color" width="100%" height="100%" fill="#f2f2f2"></rect><g data-widget-id="3458764675514511344"><g width="1018px" height="1900px"  transform="translate(0.77, 0.8) scale(1) rotate(0, 509, 950)"><svg
+	width="1018"
+	height="1900"
+	style="width:1018px; height: 1900px;"
+	class="diagram-widget"
+	preserveAspectRatio="none"
+	version="1.1"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<clipPath id="104514433991">
+		<rect x="0" y="0" width="1018" height="1900" rx="0" ry="0"></rect>
+	</clipPath>
+	<g id="Page-1" stroke="none" stroke-width="0" fill="none" fill-rule="evenodd">
+		<rect
+			class="shape-element shape-element-rect"
+			fill="#ffffff"
+			fill-opacity="1"
+			x="0"
+			y="0"
+			width="1018"
+			height="1900"
+			rx="0"
+			ry="0"
+			clip-path="url(#104514433991)"
+		></rect>
+	</g>
+	
+	<g transform="translate(0, 0)">
+		<text x="0" y="14" font-size="14"></text>
+	</g>
+</svg>
+</g></g><g data-widget-id="3458764675514319624"><g width="240px" height="120px"  transform="translate(388.77, 40.8) scale(1) rotate(0, 120, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #adf0c7;fill-opacity: 1"><rect x="0" y="0" width="240" height="120" rx="59" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="8.433334112167358" y="50" width="191.13333177566528" textLength="191.13333177566528" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Validated Pattern: rhoso-​gitops</text></g></g></g><g data-widget-id="3458764675514319625"><g width="416px" height="120px"  transform="translate(40.77, 280.8) scale(1) rotate(0, 208, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="416" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="86.44166827201843" y="42" width="211.11666345596313" textLength="211.11666345596313" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave -20: operator-​dependencies</text><text xml:space="preserve" x="138.5333330631256" y="58" width="106.93333387374878" textLength="106.93333387374878" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Infra + VSO/ESO</text></g></g></g><g data-widget-id="3458764675514319627"><g width="412px" height="120px"  transform="translate(566.77, 280.8) scale(1) rotate(0, 206, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="412" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="96.1249988079071" y="42" width="187.7500023841858" textLength="187.7500023841858" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave -20: openstack-​operator</text><text xml:space="preserve" x="127.37500083446503" y="58" width="125.24999833106995" textLength="125.24999833106995" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenStack operator</text></g></g></g><g data-widget-id="3458764675514319628"><g width="432px" height="120px"  transform="translate(292.77, 524.8) scale(1) rotate(0, 216, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="432" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="97.95833325386047" y="42" width="204.08333349227905" textLength="204.08333349227905" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave -15: openstack-​operator-​cr</text><text xml:space="preserve" x="136.20833468437195" y="58" width="127.5833306312561" textLength="127.5833306312561" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Main OpenStack CR</text></g></g></g><g data-widget-id="3458764675514319629"><g width="408px" height="120px"  transform="translate(304.77, 768.8) scale(1) rotate(0, 204, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="408" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="97.6333339214325" y="42" width="180.733332157135" textLength="180.733332157135" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave -10: openstack-​secrets</text><text xml:space="preserve" x="121.09166693687439" y="58" width="133.81666612625122" textLength="133.81666612625122" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Secure backend sync</text></g></g></g><g data-widget-id="3458764675514319630"><g width="328px" height="120px"  transform="translate(344.77, 1012.8) scale(1) rotate(0, 164, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="328" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="58.40833306312561" y="42" width="179.18333387374878" textLength="179.18333387374878" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave 0: openstack-​networks</text><text xml:space="preserve" x="118.82500076293945" y="58" width="58.349998474121094" textLength="58.349998474121094" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Networks</text></g></g></g><g data-widget-id="3458764675514319631"><g width="464px" height="120px"  transform="translate(276.77, 1252.8) scale(1) rotate(0, 232, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="464" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="112.3916642665863" y="42" width="207.2166714668274" textLength="207.2166714668274" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave 10: openstack-​controlplane</text><text xml:space="preserve" x="140.91666412353516" y="58" width="150.1666717529297" textLength="150.1666717529297" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenStackControlPlane</text></g></g></g><g data-widget-id="3458764675514319633"><g width="348px" height="120px"  transform="translate(334.77, 1496.8) scale(1) rotate(0, 174, 60)"><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #fff6b6;fill-opacity: 1"><rect x="0" y="0" width="348" height="120" rx="8" /></g></g><g><g style="stroke: #af7e02;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="61.78333258628845" y="42" width="192.4333348274231" textLength="192.4333348274231" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Wave 20: openstack-​dataplane</text><text xml:space="preserve" x="124.14999949932098" y="58" width="67.70000100135803" textLength="67.70000100135803" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Data plane</text></g></g></g><g data-widget-id="3458764675514319634"><g width="536px" height="120px"  transform="translate(240.77, 1740.8) scale(1) rotate(0, 268, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #adf0c7;fill-opacity: 1"><rect x="0" y="0" width="536" height="120" rx="59" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="174.99166655540466" y="42" width="154.01666688919067" textLength="154.01666688919067" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenShift Cluster (OCP)</text><text xml:space="preserve" x="118.20000159740448" y="58" width="267.59999680519104" textLength="267.59999680519104" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Red Hat OpenStack Services on OpenShift</text></g></g></g><g data-widget-id="3458764675514319635"><g width="1.82px" height="124.43px"  transform="translate(423.52, 156.37) scale(1) rotate(0, 0.91, 62.215)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 1.8206558706260694 0 L 1.8206558706260694 63.51930902827206 Q 1.8206558706260694 64.4296369635851 0.9103279353130347 64.4296369635851 L 0.9103279353130347 64.4296369635851 Q 0 64.4296369635851 0 65.33996489889813 L 0 114.24781878176691" clip-path="url(#LineHeadMask9AX5GE)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124.42963696358512)  rotate(90) "  /> <clipPath id="LineHeadMask9AX5GE">
+				<path d="M -2 -2 M -2 46.03423732619649 L 26.32065587062607 46.03423732619649 L 26.32065587062607 68.03423732619649 L -2 68.03423732619649 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="49" height="20" transform="translate(-22.67934412937393, 48.03423732619649) scale(1) rotate(0)"><text xml:space="preserve" x="0.6916675567626953" y="14" width="47.61666488647461" textLength="47.61666488647461" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >creates</text></g></g></g><g data-widget-id="3458764675514319637"><g width="27.25px" height="120px"  transform="translate(569.77, 160.8) scale(1) rotate(0, 13.625, 60)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 52 Q 0 60 8 60 L 19.25 60 Q 27.25 60 27.25 68 L 27.25 109.81818181818181" clip-path="url(#LineHeadMaskTutvZd)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(27.25, 119.99999999999997)  rotate(90) "  /> <clipPath id="LineHeadMaskTutvZd">
+				<path d="M -2 -2 M -2 48 L 33.03409090909091 48 L 33.03409090909091 70 L -2 70 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="49" height="20" transform="translate(-15.965909090909095, 50) scale(1) rotate(0)"><text xml:space="preserve" x="0.6916675567626953" y="14" width="47.61666488647461" textLength="47.61666488647461" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >creates</text></g></g></g><g data-widget-id="3458764675514319638"><g width="0px" height="124px"  transform="translate(375.02, 400.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 61.999999999999986 Q 0 62 1.4210854715202004e-14 62 L 1.4210854715202004e-14 62 Q 2.842170943040401e-14 62 2.842170943040401e-14 62.000000000000014 L 2.842170943040401e-14 113.81818181818181" clip-path="url(#LineHeadMask38WhR2)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMask38WhR2">
+				<path d="M -2 -2 M -2 44.90909090909092 L 42.5 44.90909090909092 L 42.5 66.90909090909092 L -2 66.90909090909092 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="85" height="20" transform="translate(-42.5, 46.90909090909092) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="84.43333649635315" textLength="84.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 20</text></g></g></g><g data-widget-id="3458764675514319639"><g width="0px" height="124px"  transform="translate(644.52, 400.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 61.999999999999986 Q 0 62 1.4210854715202004e-14 62 L 1.4210854715202004e-14 62 Q 2.842170943040401e-14 62 2.842170943040401e-14 62.000000000000014 L 2.842170943040401e-14 113.81818181818181" clip-path="url(#LineHeadMask9YEuHG)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMask9YEuHG">
+				<path d="M -2 -2 M -2 44.90909090909092 L 42.5 44.90909090909092 L 42.5 66.90909090909092 L -2 66.90909090909092 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="85" height="20" transform="translate(-42.5, 46.90909090909092) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="84.43333649635315" textLength="84.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 20</text></g></g></g><g data-widget-id="3458764675514319640"><g width="0px" height="124px"  transform="translate(508.77, 644.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskEwhzbX)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskEwhzbX">
+				<path d="M -2 -2 M -2 44.90909090909091 L 42.5 44.90909090909091 L 42.5 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="85" height="20" transform="translate(-42.5, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="84.43333649635315" textLength="84.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 15</text></g></g></g><g data-widget-id="3458764675514319642"><g width="0px" height="124px"  transform="translate(508.77, 888.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskljPeTN)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskljPeTN">
+				<path d="M -2 -2 M -2 44.90909090909091 L 42.5 44.90909090909091 L 42.5 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="85" height="20" transform="translate(-42.5, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="84.43333649635315" textLength="84.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 10</text></g></g></g><g data-widget-id="3458764675514319644"><g width="0px" height="120px"  transform="translate(508.77, 1132.8) scale(1) rotate(0, 0, 60)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 109.81818181818181" clip-path="url(#LineHeadMaskVPDn00)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 120)  rotate(90) "  /> <clipPath id="LineHeadMaskVPDn00">
+				<path d="M -2 -2 M -2 42.90909090909091 L 38.5 42.90909090909091 L 38.5 64.9090909090909 L -2 64.9090909090909 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="77" height="20" transform="translate(-38.5, 44.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="76.43333649635315" textLength="76.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 0</text></g></g></g><g data-widget-id="3458764675514319646"><g width="0px" height="124px"  transform="translate(508.77, 1372.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskRlQj4L)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskRlQj4L">
+				<path d="M -2 -2 M -2 44.90909090909091 L 42.5 44.90909090909091 L 42.5 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="85" height="20" transform="translate(-42.5, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.2833317518234253" y="14" width="84.43333649635315" textLength="84.43333649635315" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >syncWave 10</text></g></g></g><g data-widget-id="3458764675514319649"><g width="0px" height="124px"  transform="translate(508.77, 1616.8) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskMXKf3J)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskMXKf3J">
+				<path d="M -2 -2 M -2 44.90909090909091 L 34.5 44.90909090909091 L 34.5 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1018 -2 L 1018 1900 L -2 1900" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="69" height="20" transform="translate(-34.5, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.5416668653488159" y="14" width="67.91666626930237" textLength="67.91666626930237" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >deploys to</text></g></g></g></svg>

--- a/static/images/rhoso-gitops/rhoso-gitops-infrastructure.svg
+++ b/static/images/rhoso-gitops/rhoso-gitops-infrastructure.svg
@@ -1,0 +1,252 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="1450px" height="1660px"
+		style="transform-origin: 0px 0px 0px;" version="1.1"
+		xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><style xmlns="http://www.w3.org/2000/svg" type="text/css"><![CDATA[
+		* {
+			text-rendering: geometricprecision !important;
+		}
+		]]><![CDATA[@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans'), local('NotoSans'), url("https://mirostatic.com/app/static/a73798e3d459e1bc.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Noto Sans Italic'), local('NotoSans-Italic'), url("https://mirostatic.com/app/static/a8edd710f88715d4.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 500;
+  src: local('Noto Sans Medium'), local('NotoSans-Medium'), url("https://mirostatic.com/app/static/006d7e33e60b9e12.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 500;
+  src: local('Noto Sans Medium Italic'), local('NotoSans-MediumItalic'), url("https://mirostatic.com/app/static/31387059566a3171.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Noto Sans SemiBold'), local('NotoSans-SemiBold'), url("https://mirostatic.com/app/static/526dd53b40975c37.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local('Noto Sans SemiBold Italic'), local('NotoSans-SemiBoldItalic'), url("https://mirostatic.com/app/static/e73d4fdd87d7e319.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Bold'), local('NotoSans-Bold'), url("https://mirostatic.com/app/static/9f11d6779c14d2bc.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: italic;
+  font-weight: 700;
+  src: local('Noto Sans Bold Italic'), local('NotoSans-BoldItalic'), url("https://mirostatic.com/app/static/888e13e017cedc15.woff2") format('woff2');
+}
+]]><![CDATA[@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/800985e1502d12bf.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/d8a7ca42a20caea5.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/3cc74c1d3919bd5c.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/f0481285dc248cf0.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/2f5e8dcf6e47bf00.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/0e625f45b71a26f1.woff2") format('woff2');
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 800;
+  font-display: swap;
+  src: url("https://mirostatic.com/app/static/645c27eb7d93eca8.woff2") format('woff2');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans Hebrew';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans Hebrew Regular'), local('Noto Sans Hebrew-Regular'), url("https://mirostatic.com/app/static/7ebe1dcf0343326c.woff2") format('woff2'), url("https://mirostatic.com/app/static/6c11f037d6968262.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans Hebrew';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Hebrew Bold'), local('Noto Sans Hebrew-Bold'), url("https://mirostatic.com/app/static/d2883e2f177d0dad.woff2") format('woff2'), url("https://mirostatic.com/app/static/8546991909eadbc9.woff") format('woff');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans JP';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Noto Sans Japanese Regular'), local('Noto Sans Japanese-Regular'), url("https://mirostatic.com/app/static/9320b3c07ab79383.woff2") format('woff2'), url("https://mirostatic.com/app/static/a43be2cbcfc0b250.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans JP';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Noto Sans Japanese Bold'), local('Noto Sans Japanese-Bold'), url("https://mirostatic.com/app/static/7ab032c73212439f.woff2") format('woff2'), url("https://mirostatic.com/app/static/29f177f4466bd7a1.woff") format('woff');
+}
+]]><![CDATA[@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 400;
+  src: local(''), url("https://mirostatic.com/app/static/7a5b625774730d22.woff2") format('woff2'), url("https://mirostatic.com/app/static/2d84dc606f1fb88e.woff") format('woff');
+}
+@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 700;
+  src: local(''), url("https://mirostatic.com/app/static/fa5a3d9073cdd58f.woff2") format('woff2'), url("https://mirostatic.com/app/static/7ded243557c83342.woff") format('woff');
+}
+]]></style><path id="LineHeadArrow2" d="M-12.727272727272727,-7.545454545454545 L0,0 L-12.727272727272727,7.545454545454545 Z"></path></defs><rect id="svg-board-background-color" width="100%" height="100%" fill="#f2f2f2"></rect><g data-widget-id="3458764675514991909"><g width="1450px" height="1660px"  transform="translate(0.78, -0.78) scale(1) rotate(0, 725, 830)"><svg
+	width="1450"
+	height="1660"
+	style="width:1450px; height: 1660px;"
+	class="diagram-widget"
+	preserveAspectRatio="none"
+	version="1.1"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<clipPath id="1190211890793">
+		<rect x="0" y="0" width="1450" height="1660" rx="0" ry="0"></rect>
+	</clipPath>
+	<g id="Page-1" stroke="none" stroke-width="0" fill="none" fill-rule="evenodd">
+		<rect
+			class="shape-element shape-element-rect"
+			fill="#ffffff"
+			fill-opacity="1"
+			x="0"
+			y="0"
+			width="1450"
+			height="1660"
+			rx="0"
+			ry="0"
+			clip-path="url(#1190211890793)"
+		></rect>
+	</g>
+	
+	<g transform="translate(0, 0)">
+		<text x="0" y="14" font-size="14"></text>
+	</g>
+</svg>
+</g></g><g data-widget-id="3458764675514991329"><g width="192px" height="120px"  transform="translate(776.78, 39.22) scale(1) rotate(0, 96, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #adf0c7;fill-opacity: 1"><rect x="0" y="0" width="192" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="2.991666555404663" y="50" width="154.01666688919067" textLength="154.01666688919067" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenShift Cluster (OCP)</text></g></g></g><g data-widget-id="3458764675514991334"><g width="248px" height="120px"  transform="translate(468.78, 283.22) scale(1) rotate(0, 124, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c3faf5;fill-opacity: 1"><rect x="0" y="0" width="248" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="6.083332061767578" y="50" width="203.83333587646484" textLength="203.83333587646484" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Control Plane Nodes (3 masters)</text></g></g></g><g data-widget-id="3458764675514991340"><g width="160px" height="120px"  transform="translate(40.78, 527.22) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c3faf5;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="36.38333320617676" y="50" width="55.233333587646484" textLength="55.233333587646484" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >master-1</text></g></g></g><g data-widget-id="3458764675514991344"><g width="160px" height="120px"  transform="translate(308.78, 527.22) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c3faf5;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="36.38333320617676" y="50" width="55.233333587646484" textLength="55.233333587646484" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >master-2</text></g></g></g><g data-widget-id="3458764675514991352"><g width="160px" height="120px"  transform="translate(576.78, 527.22) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c3faf5;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="36.38333320617676" y="50" width="55.233333587646484" textLength="55.233333587646484" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >master-3</text></g></g></g><g data-widget-id="3458764675514991355"><g width="172px" height="120px"  transform="translate(846.78, 527.22) scale(1) rotate(0, 86, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c3faf5;fill-opacity: 1"><rect x="0" y="0" width="172" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="19.824999690055847" y="42" width="104.23333406448364" textLength="104.23333406448364" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >RHOSO Control </text><text xml:space="preserve" x="52.10000038146973" y="58" width="35.79999923706055" textLength="35.79999923706055" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Plane</text></g></g></g><g data-widget-id="3458764675514991360"><g width="168px" height="120px"  transform="translate(1144.78, 39.22) scale(1) rotate(0, 84, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #adf0c7;fill-opacity: 1"><rect x="0" y="0" width="168" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="0.32500159740448" y="50" width="135.34999680519104" textLength="135.34999680519104" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenStack Operators</text></g></g></g><g data-widget-id="3458764675514991362"><g width="252px" height="120px"  transform="translate(1102.78, 283.22) scale(1) rotate(0, 126, 60)"><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #adf0c7;fill-opacity: 1"><rect x="0" y="0" width="252" height="120" rx="8" /></g></g><g><g style="stroke: #087429;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="6.133330225944519" y="50" width="207.73333954811096" textLength="207.73333954811096" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >OpenStackControlPlane Services</text></g></g></g><g data-widget-id="3458764675514991369"><g width="280px" height="120px"  transform="translate(792.78, 771.22) scale(1) rotate(0, 140, 60)"><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c6dcff;fill-opacity: 1"><rect x="0" y="0" width="280" height="120" rx="8" /></g></g><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="8.083332896232605" y="50" width="231.8333342075348" textLength="231.8333342075348" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Data Plane Hosts (N compute nodes)</text></g></g></g><g data-widget-id="3458764675514991371"><g width="160px" height="120px"  transform="translate(852.78, 1011.22) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #dedaff;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="16.925000071525574" y="50" width="94.14999985694885" textLength="94.14999985694885" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Compute Node</text></g></g></g><g data-widget-id="3458764675514991373"><g width="160px" height="120px"  transform="translate(852.78, 1251.22) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c6dcff;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="45.32500076293945" y="50" width="37.349998474121094" textLength="37.349998474121094" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >RHEL</text></g></g></g><g data-widget-id="3458764675514991375"><g width="376px" height="120px"  transform="translate(744.78, 1495.22) scale(1) rotate(0, 188, 60)"><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #c6dcff;fill-opacity: 1"><rect x="0" y="0" width="376" height="120" rx="8" /></g></g><g><g style="stroke: #305bab;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="12.533334136009216" y="50" width="318.93333172798157" textLength="318.93333172798157" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >RHOSO Data Plane Elements (nova-​compute, etc.)</text></g></g></g><g data-widget-id="3458764675514991378"><g width="67.01px" height="165.06px"  transform="translate(716.78, 159.16) scale(1) rotate(0, 33.505, 82.53)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 67.00772212328638 0 L 67.00772212328638 157.06177698629062 Q 67.00772212328638 165.06177698629062 59.007722123286385 165.06177698629062 L 10.181818181818182 165.06177698629062" clip-path="url(#LineHeadMaskDJpkcb)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 165.06177698629062)  rotate(180) "  /> <clipPath id="LineHeadMaskDJpkcb">
+				<path d="M -2 -2 M 36.507722123286385 98.94384046387941 L 95.50772212328638 98.94384046387941 L 95.50772212328638 120.94384046387941 L 36.507722123286385 120.94384046387941 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="57" height="20" transform="translate(38.507722123286385, 100.94384046387941) scale(1) rotate(0)"><text xml:space="preserve" x="0.6499996185302734" y="14" width="55.70000076293945" textLength="55.70000076293945" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >contains</text></g></g></g><g data-widget-id="3458764675514991380"><g width="348px" height="184px"  transform="translate(120.78, 343.22) scale(1) rotate(0, 174, 92)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 348 0 L 8 0 Q 0 0 0 8 L 0 173.8181818181818" clip-path="url(#LineHeadMaskCZXXnz)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 184)  rotate(90) "  /> <clipPath id="LineHeadMaskCZXXnz">
+				<path d="M -2 -2 M 57.59090909090912 -2 L 114.59090909090912 -2 L 114.59090909090912 10 L 57.59090909090912 10 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="55" height="20" transform="translate(59.59090909090912, -10) scale(1) rotate(0)"><text xml:space="preserve" x="0.2666664123535156" y="14" width="54.46666717529297" textLength="54.46666717529297" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >includes</text></g></g></g><g data-widget-id="3458764675514991381"><g width="54px" height="184px"  transform="translate(468.78, 403.22) scale(1) rotate(0, 27, 92)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 54 0 L 54 176 Q 54 184 46 184 L 10.181818181818182 184" clip-path="url(#LineHeadMaskMk3fnv)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 184)  rotate(180) "  /> <clipPath id="LineHeadMaskMk3fnv">
+				<path d="M -2 -2 M 24.5 101.90909090909092 L 81.5 101.90909090909092 L 81.5 123.90909090909092 L 24.5 123.90909090909092 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="55" height="20" transform="translate(26.5, 103.90909090909092) scale(1) rotate(0)"><text xml:space="preserve" x="0.2666664123535156" y="14" width="54.46666717529297" textLength="54.46666717529297" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >includes</text></g></g></g><g data-widget-id="3458764675514991383"><g width="0px" height="124px"  transform="translate(646.28, 403.22) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskln0gPk)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskln0gPk">
+				<path d="M -2 -2 M -2 44.90909090909091 L 27.5 44.90909090909091 L 27.5 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="55" height="20" transform="translate(-27.5, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.2666664123535156" y="14" width="54.46666717529297" textLength="54.46666717529297" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >includes</text></g></g></g><g data-widget-id="3458764675514991384"><g width="0px" height="368px"  transform="translate(926.95, 159.22) scale(1) rotate(0, 0, 184)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 183.9999999999999 Q 0 184 1.1368683772161603e-13 184 L 1.1368683772161603e-13 184 Q 2.2737367544323206e-13 184 2.2737367544323206e-13 184.0000000000001 L 2.2737367544323206e-13 357.8181818181818" clip-path="url(#LineHeadMaskcAwKcs)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 368)  rotate(90) "  /> <clipPath id="LineHeadMaskcAwKcs">
+				<path d="M -2 -2 M -2 166.90909090909102 L 28.5 166.90909090909102 L 28.5 188.90909090909102 L -2 188.90909090909102 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="57" height="20" transform="translate(-28.5, 168.90909090909102) scale(1) rotate(0)"><text xml:space="preserve" x="0.6499996185302734" y="14" width="55.70000076293945" textLength="55.70000076293945" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >contains</text></g></g></g><g data-widget-id="3458764675514991386"><g width="0px" height="124px"  transform="translate(1228.78, 159.22) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskI6BZrO)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskI6BZrO">
+				<path d="M -2 -2 M -2 44.90909090909091 L 31 44.90909090909091 L 31 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="62" height="20" transform="translate(-31, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.6749992370605469" y="14" width="60.650001525878906" textLength="60.650001525878906" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >manages</text></g></g></g><g data-widget-id="3458764675514991387"><g width="169.33px" height="163px"  transform="translate(716.78, 364.22) scale(1) rotate(0, 84.665, 81.5)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 161.32999999999993 0 Q 169.32999999999993 0 169.32999999999993 8 L 169.32999999999993 152.8181818181818" clip-path="url(#LineHeadMasktMuZEV)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(169.32999999999993, 163)  rotate(90) "  /> <clipPath id="LineHeadMasktMuZEV">
+				<path d="M -2 -2 M 140.57409090909087 -2 L 179.57409090909087 -2 L 179.57409090909087 10 L 140.57409090909087 10 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="37" height="20" transform="translate(142.57409090909087, -10) scale(1) rotate(0)"><text xml:space="preserve" x="0.7166671752929688" y="14" width="35.56666564941406" textLength="35.56666564941406" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >hosts</text></g></g></g><g data-widget-id="3458764675514991389"><g width="0px" height="120px"  transform="translate(932.78, 891.22) scale(1) rotate(0, 0, 60)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 109.81818181818181" clip-path="url(#LineHeadMaskd1KSBS)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 120)  rotate(90) "  /> <clipPath id="LineHeadMaskd1KSBS">
+				<path d="M -2 -2 M -2 42.90909090909091 L 28.5 42.90909090909091 L 28.5 64.9090909090909 L -2 64.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="57" height="20" transform="translate(-28.5, 44.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.6499996185302734" y="14" width="55.70000076293945" textLength="55.70000076293945" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >contains</text></g></g></g><g data-widget-id="3458764675514991392"><g width="0px" height="120px"  transform="translate(932.78, 1131.22) scale(1) rotate(0, 0, 60)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 109.81818181818181" clip-path="url(#LineHeadMaskNxHqmv)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 120)  rotate(90) "  /> <clipPath id="LineHeadMaskNxHqmv">
+				<path d="M -2 -2 M -2 42.90909090909091 L 15.5 42.90909090909091 L 15.5 64.9090909090909 L -2 64.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="31" height="20" transform="translate(-15.5, 44.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.6083335876464844" y="14" width="29.78333282470703" textLength="29.78333282470703" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >runs</text></g></g></g><g data-widget-id="3458764675514991394"><g width="0px" height="124px"  transform="translate(932.78, 1371.22) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskooxGKy)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskooxGKy">
+				<path d="M -2 -2 M -2 44.90909090909091 L 30 44.90909090909091 L 30 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="60" height="20" transform="translate(-30, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.7083339691162109" y="14" width="58.58333206176758" textLength="58.58333206176758" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >supports</text></g></g></g><g data-widget-id="3458764675514991401"><g width="0px" height="124px"  transform="translate(932.78, 647.22) scale(1) rotate(0, 0, 62)"><path stroke-linecap="butt" 
+			stroke="#908e8e" stroke-width="2" fill="transparent"
+			d="M 0 0 L 0 113.81818181818181" clip-path="url(#LineHeadMaskNRoxUM)"/> <use xlink:href="#LineHeadArrow2" fill="#908e8e"
+			 transform="translate(0, 124)  rotate(90) "  /> <clipPath id="LineHeadMaskNRoxUM">
+				<path d="M -2 -2 M -2 44.90909090909091 L 27 44.90909090909091 L 27 66.9090909090909 L -2 66.9090909090909 M -2 -2 L 1450 -2 L 1450 1660 L -2 1660" fill-rule="evenodd" clip-rule="evenodd" />
+			</clipPath><g width="54" height="20" transform="translate(-27, 46.90909090909091) scale(1) rotate(0)"><text xml:space="preserve" x="0.41666603088378906" y="14" width="53.16666793823242" textLength="53.16666793823242" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Noto Sans", Helvetica, OpenSans, Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >controls</text></g></g></g><g data-widget-id="3458764675518690629"><g width="160px" height="120px"  transform="translate(871.08, 1011.92) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #dedaff;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="16.925000071525574" y="50" width="94.14999985694885" textLength="94.14999985694885" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Compute Node</text></g></g></g><g data-widget-id="3458764675518755224"><g width="160px" height="120px"  transform="translate(889.28, 1011.92) scale(1) rotate(0, 80, 60)"><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: #dedaff;fill-opacity: 1"><rect x="0" y="0" width="160" height="120" rx="8" /></g></g><g><g style="stroke: #6631d7;stroke-width: 2;stroke-opacity: 1;stroke-dasharray: none;stroke-linecap: round;stroke-linejoin: round;fill: transparent;fill-opacity: 0"></g></g><g transform="translate(16, 16)"><text xml:space="preserve" x="14.591666102409363" y="50" width="98.81666779518127" textLength="98.81666779518127" lengthAdjust="spacingAndGlyphs" letter-spacing="0" font-family='"Arial", Arial, sans-serif, Noto Sans Hebrew, Noto Sans, Noto Sans JP, Noto Sans KR' font-size="14" 
+				fill="#222428" direction="ltr" >Compute nodes</text></g></g></g></svg>


### PR DESCRIPTION
Add sandbox-tier documentation for the RHOSO GitOps pattern: overview, getting started, cluster sizing, configuration, and troubleshooting pages, reusable AsciiDoc modules, metadata from pattern-metadata.yaml, shared RHOSO attributes, and spellcheck wordlist entries.

~~Pattern repository links use cjeanner/pattern-rhoso-gitops for now. TODO(repo-move) comments mark github, bugs, and deploy URLs to update once the repo moves to validatedpatterns-sandbox/rhoso-gitops.~~

Architecture diagrams (GitOps delivery and infrastructure topology) were created on Miro and exported as SVG under static/images/rhoso-gitops/.

AI-Assist: Cursor; model=Composer; mode=agent; origin=cursor