### PR TITLE
fix: add missing next and previous page buttons on the contribute pages

### DIFF
--- a/layouts/contribute/single.html
+++ b/layouts/contribute/single.html
@@ -13,6 +13,9 @@
         {{ partial "toc.html" . }}
         <div class="pf-c-content">
           {{ .Content }}
+
+          <!-- Page Navigation -->
+          {{ partial "page-navigation.html" . }}
         </div>
       </div>
     </section>

--- a/layouts/partials/page-navigation.html
+++ b/layouts/partials/page-navigation.html
@@ -3,7 +3,7 @@
 {{ $nextPage := false }}
 {{ $prevPage := false }}
 
-{{ if or (eq .Section "learn") (eq .Section "workshop") }}
+{{ if in (slice "learn" "workshop" "contribute") .Section }}
   {{/* For learn/workshop sections, use the menu system to get the correct order */}}
   {{ $menuName := .Section }}
   {{ $allMenuItems := slice }}


### PR DESCRIPTION
Two things were missing on Contribute pages:

1. `layouts/contribute/single.html` did not include the page navigation partial (Learn and Workshop already did).
2. `layouts/partials/page-navigation.html` only built prev/next from the sidebar menu for Learn and Workshop. Contribute fell back to a flat weight sort that ignored menu hierarchy.

Current:
<img width="1705" height="641" alt="image" src="https://github.com/user-attachments/assets/c9bfb3ce-287b-4add-860d-353da03b45d2" />

This PR:
<img width="1705" height="507" alt="image" src="https://github.com/user-attachments/assets/225bd078-2db4-475f-b651-86491cbc95aa" />

