### PR TITLE
[rhoso-gitops] singleArgoCD: true by default

### DIFF
--- a/content/patterns/rhoso-gitops/cluster-sizing.adoc
+++ b/content/patterns/rhoso-gitops/cluster-sizing.adoc
@@ -10,6 +10,9 @@ include::modules/comm-attributes.adoc[]
 :imagesdir: /images
 include::modules/rhoso-gitops/metadata-rhoso-gitops.adoc[]
 
+Review the cluster and data plane host requirements before you deploy the
+{rhoso-gitops-pattern}.
+
 [id="rhoso-gitops-cluster-requirements"]
 == Cluster requirements
 

--- a/content/patterns/rhoso-gitops/secret-management.adoc
+++ b/content/patterns/rhoso-gitops/secret-management.adoc
@@ -203,13 +203,7 @@ bootstrap_secrets:
         path: ~/vault-approle-secret-id
         onMissingValue: error
 
-secrets:
-  - name: osp-secret
-    fields:
-      - name: AdminPassword
-        value: "__<admin-password>__"
-      # ... remaining service password fields
-  # ... remaining secrets
+secrets: []
 ----
 
 . Install the pattern:

--- a/content/patterns/rhoso-gitops/troubleshooting.adoc
+++ b/content/patterns/rhoso-gitops/troubleshooting.adoc
@@ -88,7 +88,7 @@ $ oc logs -n __<namespace>__ __<pod_name>__
 The following known issues can affect pattern deployment:
 
 * *`openstack-secrets` disabled*: The default pattern leaves
-  `openstack-secrets` disabled because no Git path exists (`path: TODO`).
+  `openstack-secrets` disabled because no Git path exists.
   Enable it only after you configure secret wiring. See
   link:../secret-management/[Secret management for the {rhoso-gitops-pattern}].
 * *Upstream sync failures*: Confirm that `targetRevision` and paths in

--- a/content/patterns/rhoso-gitops/troubleshooting.adoc
+++ b/content/patterns/rhoso-gitops/troubleshooting.adoc
@@ -45,7 +45,7 @@ $ ./pattern.sh make argo-healthcheck
 [id="rhoso-gitops-check-argocd"]
 == Checking Argo CD application status
 
-The pattern uses two Argo CD namespaces. List applications in each namespace:
+All Argo CD applications run in the `vp-gitops` namespace:
 
 . List applications in `vp-gitops`:
 +
@@ -54,22 +54,15 @@ The pattern uses two Argo CD namespaces. List applications in each namespace:
 $ oc get applications -n vp-gitops
 ----
 
-. List applications in `rhoso-gitops-standalone`:
-+
-[source,terminal]
-----
-$ oc get applications -n rhoso-gitops-standalone
-----
-
 . Inspect a child application that is out of sync or unhealthy:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc describe application __<application_name>__ -n rhoso-gitops-standalone
+$ oc describe application __<application_name>__ -n vp-gitops
 ----
 
-Use the Argo CD UI in the `rhoso-gitops-standalone` namespace to review
-application status, resource health, and diff details for upstream overlays.
+Use the Argo CD UI in the `vp-gitops` namespace to review application status,
+resource health, and diff details for upstream overlays.
 
 [id="rhoso-gitops-check-pods"]
 == Checking pod status

--- a/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
+++ b/modules/rhoso-gitops/metadata-rhoso-gitops.adoc
@@ -2,7 +2,7 @@
 // Do not edit manually!
 :metadata_version: 1.0
 :name: rhoso-gitops
-:description: Deploy Red Hat OpenStack Services on OpenShift (RHOSO) using GitOps via the rhoso-gitops meta-chart and upstream Kustomize example overlays.
+:description: Deploy Red Hat OpenStack Services on OpenShift (RHOSO) by using GitOps through the rhoso-gitops meta-chart and upstream Kustomize example overlays.
 :pattern_version: 0.1.0
 :display_name: RHOSO GitOps
 :repo_url: https://github.com/validatedpatterns-sandbox/rhoso-gitops

--- a/modules/rhoso-gitops/rhoso-gitops-about.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-about.adoc
@@ -54,7 +54,7 @@ fan-out.
 | Yes
 | {solution-name-upstream} clustergroup (`values-standalone.yaml`),
   *rhoso-gitops* meta-chart, and child {rh-rhoso-short} Applications in
-  `rhoso-gitops-standalone`
+  `vp-gitops`
 
 | Managed clusters
 | None

--- a/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
@@ -6,7 +6,7 @@
 
 The {rhoso-gitops-pattern} delivers {rh-rhoso-short} configuration through Argo CD
 Applications that the *rhoso-gitops* meta-chart creates. The pattern uses GitOps
-delivery through dual Argo CD namespaces, manages infrastructure topology, and
+delivery through a single Argo CD namespace, manages infrastructure topology, and
 converges deployment through retry policies.
 
 [id="rhoso-gitops-gitops-delivery"]
@@ -23,29 +23,28 @@ The delivery path is:
 . The {validated-patterns-op} reconciles the pattern clustergroup
 . The parent *rhoso-gitops* Application runs in `vp-gitops`
   ({solution-name-upstream} GitOps)
-. The meta-chart renders child Applications in `rhoso-gitops-standalone`
-  (dedicated Argo CD instance)
+. The meta-chart renders child Applications in the same `vp-gitops` namespace
 . The child applications sync upstream `example/*` overlays (Operators,
   networks, control plane, data plane) and converge through retry policies
 
 .GitOps application delivery
 image::rhoso-gitops/rhoso-gitops-applications.png[{rhoso-gitops-pattern} GitOps application delivery]
 
-The parent Application runs in `vp-gitops`. Child Applications in
-`rhoso-gitops-standalone` sync upstream Kustomize overlays.
-All child Applications deploy at sync-wave 0 and converge eventually through
-retry policies.
+Both the parent Application and child Applications run in `vp-gitops` and sync
+upstream Kustomize overlays. All child Applications deploy at sync-wave 0 and
+converge eventually through retry policies.
 
-[id="rhoso-gitops-dual-argocd"]
-== Dual Argo CD namespaces
+[id="rhoso-gitops-argocd-namespace"]
+== Argo CD namespace
 
-The pattern uses two Argo CD namespaces:
+The pattern runs all Argo CD Applications in a single *`vp-gitops`* namespace,
+enabled by `global.singleArgoCD: true` in `values-global.yaml`. The
+{validated-patterns-op} deploys the parent *rhoso-gitops* Application into
+`vp-gitops`, and the meta-chart creates child {rh-rhoso-short} Applications in
+the same namespace.
 
-* The {validated-patterns-op} deploys the parent *rhoso-gitops* Application into
-  *`vp-gitops`* ({solution-name-upstream} GitOps).
-* The meta-chart creates child {rh-rhoso-short} Applications in *`rhoso-gitops-standalone`*,
-  a dedicated Argo CD instance managed by the pattern (see `applicationNamespace`
-  in the chart).
+For background on this option, see the
+link:https://validatedpatterns.io/blog/2026-06-04-single-argocd-option/[single ArgoCD blog post].
 
 [id="rhoso-gitops-infrastructure-topology"]
 == Infrastructure topology
@@ -79,4 +78,4 @@ link:configuration/#rhoso-gitops-configuration[Configuration] >
 link:configuration/#rhoso-gitops-upstream-applications[Upstream applications].
 
 After you change overrides, confirm child applications in the Argo CD UI or with
-`oc get applications -n rhoso-gitops-standalone`.
+`oc get applications -n vp-gitops`.

--- a/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-architecture.adoc
@@ -30,9 +30,8 @@ The delivery path is:
 .GitOps application delivery
 image::rhoso-gitops/rhoso-gitops-applications.png[{rhoso-gitops-pattern} GitOps application delivery]
 
-Both the parent Application and child Applications run in `vp-gitops` and sync
-upstream Kustomize overlays. All child Applications deploy at sync-wave 0 and
-converge eventually through retry policies.
+All child Applications deploy at sync-wave 0 and converge eventually through
+retry policies.
 
 [id="rhoso-gitops-argocd-namespace"]
 == Argo CD namespace
@@ -43,7 +42,7 @@ enabled by `global.singleArgoCD: true` in `values-global.yaml`. The
 `vp-gitops`, and the meta-chart creates child {rh-rhoso-short} Applications in
 the same namespace.
 
-For background on this option, see the
+For more information about this option, see the
 link:https://validatedpatterns.io/blog/2026-06-04-single-argocd-option/[single ArgoCD blog post].
 
 [id="rhoso-gitops-infrastructure-topology"]
@@ -59,7 +58,7 @@ infrastructure topology defines *what* gets deployed:
 .{rh-rhoso-short} infrastructure topology
 image::rhoso-gitops/rhoso-gitops-infrastructure.png[{rhoso-gitops-pattern} infrastructure topology]
 
-* *OpenShift cluster*: Control-plane nodes run OpenStack Operators and
+* *{rh-ocp} cluster*: Control-plane nodes run OpenStack Operators and
   `OpenStackControlPlane` services.
 * *Data plane hosts*: One or more {rhel-short} compute nodes run {rh-rhoso-short}
   data plane elements and connect to the control plane.

--- a/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
@@ -41,9 +41,9 @@ The clustergroup application in `values-standalone.yaml` points Argo CD at
 | Optional platform-specific overrides (placeholder)
 |===
 
-To change upstream Git content (revision, paths, enable or disable applications), edit
-`overrides/values-rhoso-gitops.yaml` and sync the pattern (or let automated
-sync reconcile, per `global.options.syncPolicy` in `values-global.yaml`).
+To change upstream Git content (revision, paths, or enabled applications), edit
+`overrides/values-rhoso-gitops.yaml`. The pattern syncs automatically if
+`global.options.syncPolicy` is set to `Automatic` in `values-global.yaml`.
 
 [id="rhoso-gitops-upstream-applications"]
 == Upstream applications
@@ -82,7 +82,7 @@ To deploy {rh-rhoso-short}, point each application at your own Git overlay
 
 | `openstack-secrets`
 | Secure-backend sync (disabled by default)
-| not configured (`path: TODO`)
+| not configured
 | link:https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/latest/html/deploying_red_hat_openstack_services_on_openshift/assembly_preparing-rhocp-for-rhoso#proc_providing-secure-access-to-the-RHOSO-services_preparing[Providing secure access to the RHOSO services]
 
 | `openstack-networks`

--- a/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-configuration.adoc
@@ -22,7 +22,7 @@ The clustergroup application in `values-standalone.yaml` points Argo CD at
 
 | Pattern global
 | `values-global.yaml`
-| Pattern name, sync policy, clustergroup chart version
+| Pattern name, sync policy, singleArgoCD mode, custom ArgoCD health checks
 
 | Cluster group
 | `values-standalone.yaml`

--- a/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
@@ -89,13 +89,6 @@ $ ./pattern.sh make install
 $ oc get applications -n vp-gitops
 ----
 
-. List Argo CD applications in `rhoso-gitops-standalone`:
-+
-[source,terminal]
-----
-$ oc get applications -n rhoso-gitops-standalone
-----
-
 . After installation, run the pattern health check:
 +
 [source,terminal]

--- a/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
+++ b/modules/rhoso-gitops/rhoso-gitops-deploying.adoc
@@ -46,6 +46,10 @@ $ git clone git@github.com:__<your_organization>__/rhoso-gitops.git
 $ cd rhoso-gitops
 ----
 
+. Configure your overrides. See
+  link:../configuration/[{rhoso-gitops-pattern} configuration] for the values
+  file layers and override options.
+
 . Configure your secrets file before installing. See
   link:../secret-management/[Secret management for the {rhoso-gitops-pattern}]
   for instructions on both the {hashicorp-vault-short} + {eso-op} and direct


### PR DESCRIPTION
- Update all rhoso-gitops documentation to reflect singleArgoCD: true as the default: replace every rhoso-gitops-standalone namespace reference with vp-gitops, rewrite the "Dual Argo CD namespaces" architecture section to
  describe a single namespace, remove duplicate oc get applications verification steps, and update the values-global.yaml table row to mention singleArgoCD mode and custom health checks

- Apply Red Hat/IBM style guide fixes: replace "via" with "by using", use {rh-ocp} attribute instead of hard-coded "OpenShift", remove redundant paragraph, split a 34-word sentence, add missing short description to the
  cluster-sizing page, add cross-reference link for the new overrides configuration step, and use "about" instead of "on" in link intros

Depends-on: https://github.com/validatedpatterns-sandbox/rhoso-gitops/pull/30